### PR TITLE
Allow single character duty station lookup

### DIFF
--- a/apps/service_member.py
+++ b/apps/service_member.py
@@ -43,7 +43,7 @@ class ServiceMemberSignupFlow(BaseTaskSequence, InternalAPIMixin):
         self.user["service_member"] = service_member
 
     def get_dutystations(self, short_name):
-        station_list = [short_name[0:3], short_name]
+        station_list = [short_name[0], short_name[0:3], short_name]
         duty_stations = None
         for station in station_list:
             duty_stations = swagger_request(


### PR DESCRIPTION
The API still lets us do single character duty station lookup. So this modifies the load testing to be in line with what is allowed by the API (even though the client only passes through 2 character searches).