### PR TITLE
MB-3080 Makes newly created mto available to prime

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -90,6 +90,7 @@ class SupportTasks(CertTaskSet):
                 support_path(f"/move-task-orders/{move_task_order_id}/available-to-prime"),
                 headers=headers,
                 **self.user.cert_kwargs,
+                name=support_path("/move-task-orders/:moveTaskOrderID/available-to-prime"),
             )
 
             logger.info(f"ℹ️ Make MTO available to Prime status code: {resp.status_code}")

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -82,3 +82,14 @@ class SupportTasks(CertTaskSet):
             logger.exception("Non-JSON response")
         else:
             logger.info(f"ℹ️ MoveTaskOrder {json_body['id']} created!")
+
+            move_task_order_id = json_body["id"]
+            e_tag = json_body["eTag"]
+            headers["if-match"] = e_tag
+            resp = self.client.patch(
+                support_path(f"/move-task-orders/{move_task_order_id}/available-to-prime"),
+                headers=headers,
+                **self.user.cert_kwargs,
+            )
+
+            logger.info(f"ℹ️ Make MTO available to Prime status code: {resp.status_code}")


### PR DESCRIPTION
## Description

* In order to build the Prime API task sequence, we need to make every newly created MTO available to prime. 
* This PR adds that functionality to the existing createMoveTaskOrder task in the Support task set.

## Reviewer Notes

Sandy and I discussed keeping it in the createMoveTaskOrder function since this is specific to the Prime API and we need every MTO to be available to Prime. Let me know if you have any other thoughts on structure!

## Setup

```sh
locust -f locustfiles/prime.py
```

* Open http://localhost:8089/
* Enter values for users, hatch rate, and `local` for host
* Run and observe. You should see plenty of PATCH requests to `/available-to-prime`.

## Code Review Verification Steps
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3080) for this change.
