### PR TITLE
MB-2712 Adds Locust Task for Create upload

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -127,7 +127,10 @@ class PrimeTasks(CertTaskSet):
         upload_file = {"file": open(TEST_PDF, "rb")}
 
         resp = self.client.post(
-            prime_path(f"/payment-requests/{payment_request_id}/uploads"), files=upload_file, **self.user.cert_kwargs
+            prime_path(f"/payment-requests/{payment_request_id}/uploads"),
+            files=upload_file,
+            name=prime_path("/payment-requests/:paymentRequestID/uploads"),
+            **self.user.cert_kwargs,
         )
 
         logger.info(f"ℹ️ Create Upload status code: {resp.status_code}")

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -5,6 +5,7 @@ import json
 
 from locust import tag, task
 
+from utils.constants import TEST_PDF
 from .base import CertTaskSet
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,25 @@ class PrimeTasks(CertTaskSet):
             logger.exception("Non-JSON response")
         else:
             logger.info(f"ℹ️ MTOShipment {json_body['id']} created!")
+
+    @tag("paymentRequest", "createUpload")
+    @task
+    def create_upload(self):
+        payment_request_id = "a2c34dba-015f-4f96-a38b-0c0b9272e208"
+        upload_file = {"file": open(TEST_PDF, "rb")}
+
+        resp = self.client.post(
+            prime_path(f"/payment-requests/{payment_request_id}/uploads"), files=upload_file, **self.user.cert_kwargs
+        )
+
+        logger.info(f"ℹ️ Create Upload status code: {resp.status_code}")
+
+        try:
+            json_body = json.loads(resp.content)
+        except (json.JSONDecodeError, TypeError):
+            logger.exception("Non-JSON response")
+        else:
+            logger.info(f"ℹ️ Upload {json_body['filename']} created!")
 
 
 @tag("support")

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -7,6 +7,7 @@ from .base import ImplementationError, ListEnum
 STATIC_FILES = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "static")
 LOCAL_MTLS_CERT = os.path.join(STATIC_FILES, "certs/devlocal-mtls.cer")
 LOCAL_MTLS_KEY = os.path.join(STATIC_FILES, "certs/devlocal-mtls.key")
+TEST_PDF = os.path.join(STATIC_FILES, "test.pdf")
 
 PRIME_CERT_KWARGS = {"cert": (LOCAL_MTLS_CERT, LOCAL_MTLS_KEY), "verify": False}
 


### PR DESCRIPTION
## Description

This PR adds `createUpload` handler to the `PrimeTasksSet` for load testing integration. 

## Reviewer Notes

See inline comments. 

## Setup

1. Start and run `mymove` Prime API
```sh
mylaptop ~ %: cd /mymove
mylaptop ~ %: make server_run
```

2. Load end to end data depended for load test. 
```sh
mylaptop mymove  %: make db_dev_e2e_populate
```

3. Start Locust load testing framework and run `createUpload` test. 
```sh
mylaptop ~ %: cd /milmove_load_testing
mylaptop milmove_load_testing  %: locust -f locustfiles/prime.py --host local -T createUpload 
```

4. After starting load tests, ensure handler responds with `200` status code 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2712) for this change.
