### PR TITLE
MB-2968 Update README with APIParser instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ in the [LICENSE.txt](./LICENSE.txt) file in this repository.
          * [Starting from scratch](#starting-from-scratch)
          * [Creating TaskSets](#creating-tasksets)
          * [Adding tasks to existing load tests](#adding-tasks-to-existing-load-tests)
+      * [Fake Data Generation](#fake-data-generation)
+         * [Creating a custom parser](#creating-a-custom-parser)
       * [Load Testing against AWS Experimental Environment](#load-testing-against-aws-experimental-environment)
          * [Handling Rate Limiting](#handling-rate-limiting)
          * [Metrics](#metrics)
       * [References](#references)
 
-<!-- Added by: sandy, at: Mon Jul 13 15:37:31 CDT 2020 -->
+<!-- Added by: sandy, at: Tue Jul 14 14:09:41 CDT 2020 -->
 
 <!--te-->
 <!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -438,7 +438,111 @@ parser.generate_fake_request(path="/mto-service-items", method="post", overrides
 
 ### Creating a custom parser
 
-The `APIParser` class is designed to be inherited and customized for specific APIs.
+The `APIParser` class is designed to be inherited and customized for specific APIs. To start, go to the bottom of the
+`utils/parsers.py` file and create a new class with the link to your API YAML file:
+
+```python
+class GHCAPIParser(APIParser):
+    """ Parsing the GHC API as an example: """
+
+    api_file = "https://raw.githubusercontent.com/transcom/mymove/master/swagger/ghc.yaml"
+```
+
+The `APIParser` has three built-in hook methods that are designed to make it easier to implement custom data
+manipulation in your parser class:
+
+```python
+class GHCAPIParser(APIParser):
+    ...
+
+    def _custom_field_validation(self, field, object_def):
+        """
+        This hook is for changes you want to make to a specific field, regardless of which endpoint it is used in.
+        These are PRE-DATA changes and will be used to generate the data you want for this field whenever you call the
+        generate_fake_data method.
+        """
+        # Example:
+        if field.name == "agents":
+            try:
+                field.max_items == 2  # let's say we never want more than two agents, regardless of what the YAML says
+            except AttributeError:
+                pass  # this wasn't the field type we were expecting -- should log as well
+
+    def _custom_body_validation(self, body):
+        """
+        This hook is for changes you want to make to a specific APIEndpointBody class (defined in utils/fields.py).
+        These are PRE-DATA changes and will be used to generate the data you want for this endpoint whenever you call
+        the generate_fake_data method.
+        """
+        # Example:
+        if body.path.endswith("status") and body.method == "patch":
+            if body.body_field.object_fields:  # make sure we have the right BaseAPIField type
+                status_field = body.body_field.get_field("status")
+                if status_field and status_field.options:  # check that we have the field and it is an EnumField
+                    try:
+                        # status will already be SUBMITTED and can't be changed back, so let's just remove that option:
+                        status_field.options.remove("SUBMITTED")
+                    except ValueError:
+                        pass  # it's not in the list, so we're good
+
+    def _custom_request_validation(self, path, method, request_data):
+        """
+        This hook is for changes you want to make to the data for a specific endpoint AFTER generation. This code
+        manipulates actual data and may not apply to every request.
+        """
+        # Example:
+        if path == "/move-task-orders/{moveTaskOrderID}" and method == "patch":
+            if request_data.get("isCanceled"):  # check if this value was set and if it's True
+                request_data["availableToPrimeAt"] = None
+```
+
+Next, instantiate the parser in your `locustfile` and reference it in the `parser` attribute on your `User` class:
+
+```python
+from utils.parsers import GHCAPIParser
+
+ghc_parser = GHCAPIParser()
+
+
+GHCUser(...):
+    ...
+
+    parser = ghc_parser
+```
+
+Instantiating it once at the beginning of the `locustfile` keeps the API from being reparsed over and over, saving you
+valuable processing time.
+
+Next, navigate to your `TaskSet` class and add the `ParserTaskMixin` to its inheritance:
+
+```python
+from tasks.base import ParserTaskMixin
+
+
+GHCTaskSet(ParserTaskMixin, ...):  # ParserTaskMixin needs to be BEFORE the other classes in the MRO
+```
+
+This gives you access to the `self.fake_request` method, and now you can generate a request body filled with fake data:
+
+```python
+GHCTaskSet(ParserTaskMixin, ...):
+    ...
+
+    @task
+    def update_move_task_order(self):
+        mtoID = "5d4b25bb-eb04-4c03-9a81-ee0398cb779e"
+        payload = self.fake_request(path="/move-task-orders/{moveTaskOrderID}", method="patch")
+
+        response = self.client.patch(
+            f"/ghc/v1/move-task-orders/{mtoID}",
+            name="/ghc/v1/move-task-orders/{moveTaskOrderID}",
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+
+        # Now process the response however you like:
+        print(response.status_code, response.content)
+```
 
 ## Load Testing against AWS Experimental Environment
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,51 @@ research and just a bit of coding. Here are the general steps:
 * Run the load test and check that your task is working properly.
   * If it is, you're good to go!
 
+## Fake Data Generation
+
+This repo also contains a tool to generate fake data for creating dynamic request bodies and simulating more varied user
+behavior, the `APIParser` class. It parses an API `.yaml` file using a path or URL using the `prance` library to create
+a fully-resolved dictionary of its Swagger specification. The main methods are:
+
+* `get_request_body`: Returns the full Swagger specification of the request body for a given endpoint. Requires the
+`path` and the `method` (post, get, etc) to be passed in. Returns an empty dictionary if no matching request found.
+
+```python
+from utils.parsers import APIParser
+
+parser = APIParser(api_file="https://raw.githubusercontent.com/transcom/mymove/master/swagger/prime.yaml")
+parser.get_request_body(path="/mto-shipments", method="post")
+```
+
+* `get_response_body`: Returns the full Swagger specification of the response for a given endpoint. Requires the
+`path` and the `method` (post, get, etc). Optionally accepts the `status` code for the response, which defaults to
+`"200"`. Returns an empty dictionary if no matching response is found.
+
+```python
+parser.get_response_body(path="/mto-service-items", method="post", status="201")
+```
+
+* `get_definition`: Returns the full Swagger specification for a specific definition. Requires the `name` of the
+definition to be passed in. Returns `None` if no matching definition is found.
+
+```python
+parser.get_definition(name="MoveTaskOrder")
+```
+
+* `generate_fake_request`: Takes in the endpoint `path` and `method` and returns a JSON-ready dictionary with the fields
+and fake data for the request. Uses the `faker` library to generate the data. Can optionally accept a dictionary of
+`overrides` for top-level fields that should have specific fields, a dictionary of `nested_overrides` for fields in
+child objects that should have specific data, or a boolean `require_all` that indicates that all fields should be
+filled, even if not required.
+
+```python
+parser.generate_fake_request(path="/mto-service-items", method="post", overrides={"modelType": "MTOServiceItemDDSFIT"})
+```
+
+### Creating a custom parser
+
+The `APIParser` class is designed to be inherited and customized for specific APIs.
+
 ## Load Testing against AWS Experimental Environment
 
 To load test against the AWS Experimental Environment you must modify the

--- a/README.md
+++ b/README.md
@@ -11,6 +11,39 @@ the public domain. In places where it is eligible for copyright, such as some fo
 this work is licensed under [the MIT License](https://opensource.org/licenses/MIT), the full text of which is included
 in the [LICENSE.txt](./LICENSE.txt) file in this repository.
 
+## Table of Contents
+
+<!-- Uses gh-md-toc to generate Table of Contents: https://github.com/ekalinin/github-markdown-toc -->
+<!-- markdownlint-disable -->
+<!--ts-->
+   * [MilMove Load Testing](#milmove-load-testing)
+      * [License Information](#license-information)
+      * [Table of Contents](#table-of-contents)
+      * [Overview](#overview)
+         * [locustfiles/](#locustfiles)
+         * [tasks/](#tasks)
+         * [utils/](#utils)
+      * [Getting Started](#getting-started)
+         * [Requirements](#requirements)
+         * [Alternate Setup](#alternate-setup)
+      * [Running Load Tests](#running-load-tests)
+         * [Setting up the local environment](#setting-up-the-local-environment)
+         * [Running preset tests](#running-preset-tests)
+         * [Running custom tests](#running-custom-tests)
+      * [Adding Load Tests](#adding-load-tests)
+         * [Starting from scratch](#starting-from-scratch)
+         * [Creating TaskSets](#creating-tasksets)
+         * [Adding tasks to existing load tests](#adding-tasks-to-existing-load-tests)
+      * [Load Testing against AWS Experimental Environment](#load-testing-against-aws-experimental-environment)
+         * [Handling Rate Limiting](#handling-rate-limiting)
+         * [Metrics](#metrics)
+      * [References](#references)
+
+<!-- Added by: sandy, at: Mon Jul 13 15:37:31 CDT 2020 -->
+
+<!--te-->
+<!-- markdownlint-restore -->
+
 ## Overview
 
 MilMove is a system to help service members (and other authorized personnel) move their gear and possessions from one

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -124,6 +124,20 @@ class ObjectField(BaseAPIField):
         else:
             self.add_field(field)
 
+    def get_field(self, field_name):
+        """
+        Searches the object_fields list for a field matching the specific name passed in. Returns the BaseAPIField
+        object if found; otherwise, returns None.
+
+        :param field_name: str
+        :return: BaseAPIField or None
+        """
+        for field in self.object_fields:
+            if field.name == field_name:
+                return field
+
+        return None
+
     def update_required_fields(self, required_fields):
         """
         Takes in a list of required fields for the object and updates the `required` attribute for each of them.
@@ -155,9 +169,9 @@ class ObjectField(BaseAPIField):
             if overrides and self.discriminator in overrides:
                 return overrides[self.discriminator]  # if the user passed in an explicit discriminator value, use it
 
-            for field in self.object_fields:
-                if field.name == self.discriminator:
-                    return field.generate_fake_data(faker)
+            discriminator_field = self.get_field(self.discriminator)
+            if discriminator_field:
+                return discriminator_field.generate_fake_data(faker)
 
         return ""  # return an empty string if we can't determine a value
 


### PR DESCRIPTION
## Description

This PR updates the README with detailed instructions/examples for how to use the `APIParser` class to generate fake data for a request. It also adds a little function to the `ObjectField` class because it made sense to have one after thinking more about use-cases for examples.


## Setup

Read the instructions under [Fake Data Generation](https://github.com/transcom/milmove_load_testing/tree/sw-mb-2968-update-readme#fake-data-generation) and run the Prime load tests to check that my code updates didn't break testing.

In the `mymove` directory:

```sh
make db_dev_e2e_populate
make server_run
```

In the `milmove_load_testing` directory:

```sh
make rebuild
make load_test_prime
```

Pay special attention to the `/mto-service-items` endpoint as the change would cause this one to fail if it was set up incorrectly. 

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2968?focusedCommentId=12421&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-12421) for this change.
