### PR TITLE
MB-2970 Connect name and address fields to approved data json

### DIFF
--- a/static/fake_data.json
+++ b/static/fake_data.json
@@ -1,0 +1,234 @@
+{
+  "names": [
+    {
+      "first_name": "Jason",
+      "last_name": "Ash"
+    },
+    {
+      "first_name": "Riley",
+      "last_name": "Baker"
+    },
+    {
+      "first_name": "Aaliyah",
+      "last_name": "Banks"
+    },
+    {
+      "first_name": "Ashley",
+      "last_name": "Banks"
+    },
+    {
+      "first_name": "Angel",
+      "last_name": "Bauer"
+    },
+    {
+      "first_name": "Jaime",
+      "last_name": "Childers"
+    },
+    {
+      "first_name": "Sofía",
+      "last_name": "Clark-Nuñez"
+    },
+    {
+      "first_name": "Justice",
+      "last_name": "Connelly"
+    },
+    {
+      "first_name": "Zoya",
+      "last_name": "Darvish"
+    },
+    {
+      "first_name": "Reese",
+      "last_name": "Embry"
+    },
+    {
+      "first_name": "Robin",
+      "last_name": "Fenstermacher"
+    },
+    {
+      "first_name": "Grace",
+      "last_name": "Griffin"
+    },
+    {
+      "first_name": "Laura Jane",
+      "last_name": "Henderson"
+    },
+    {
+      "first_name": "Skyler",
+      "last_name": "Hunt"
+    },
+    {
+      "first_name": "Jayden",
+      "last_name": "Jackson Jr."
+    },
+    {
+      "first_name": "Dorothy",
+      "last_name": "Lagomarsino"
+    },
+    {
+      "first_name": "John",
+      "last_name": "Lee"
+    },
+    {
+      "first_name": "Jonathan",
+      "last_name": "Lee"
+    },
+    {
+      "first_name": "Lisa",
+      "last_name": "Lee"
+    },
+    {
+      "first_name": "Susan",
+      "last_name": "Lee"
+    },
+    {
+      "first_name": "W. Nathan",
+      "last_name": "Millering"
+    },
+    {
+      "first_name": "Owen",
+      "last_name": "Nance"
+    },
+    {
+      "first_name": "Avery",
+      "last_name": "O'Keefe"
+    },
+    {
+      "first_name": "Quinn",
+      "last_name": "Ocampo"
+    },
+    {
+      "first_name": "Josh",
+      "last_name": "Perez"
+    },
+    {
+      "first_name": "Jody",
+      "last_name": "Pitkin"
+    },
+    {
+      "first_name": "Saqib",
+      "last_name": "Rahman"
+    },
+    {
+      "first_name": "Carol",
+      "last_name": "Romilly"
+    },
+    {
+      "first_name": "James",
+      "last_name": "Rye"
+    },
+    {
+      "first_name": "Gabriela",
+      "last_name": "Sáenz Perez"
+    },
+    {
+      "first_name": "Jessica",
+      "last_name": "Smith"
+    },
+    {
+      "first_name": "Kerry",
+      "last_name": "Smith"
+    },
+    {
+      "first_name": "Ted",
+      "last_name": "Smith"
+    },
+    {
+      "first_name": "Barbara",
+      "last_name": "St. Juste"
+    },
+    {
+      "first_name": "Christopher",
+      "last_name": "Swinglehurst-Walters"
+    },
+    {
+      "first_name": "Melissa",
+      "last_name": "Taylor"
+    },
+    {
+      "first_name": "Edgar",
+      "last_name": "Taylor III"
+    },
+    {
+      "first_name": "Casey",
+      "last_name": "Thompson"
+    },
+    {
+      "first_name": "Gregory",
+      "last_name": "Van der Heide"
+    },
+    {
+      "first_name": "Catalina",
+      "last_name": "Washington"
+    },
+    {
+      "first_name": "Rosalie",
+      "last_name": "Wexler"
+    },
+    {
+      "first_name": "Nevaeh",
+      "last_name": "Wilson"
+    },
+    {
+      "first_name": "Peyton",
+      "last_name": "Wing"
+    },
+    {
+      "first_name": "Jo",
+      "last_name": "Xi"
+    },
+    {
+      "first_name": "Earl",
+      "last_name": "Yazzie"
+    }
+  ],
+  "addresses": [
+    {
+      "address": "7 Q St"
+    },
+    {
+      "address": "17 8th St"
+    },
+    {
+      "address": "9 W 2nd Ave"
+    },
+    {
+      "address": "148 S East St"
+    },
+    {
+      "address": "412 Avenue M #3E"
+    },
+    {
+      "address": "10642 N Second Ave"
+    },
+    {
+      "address": "812 S 129th Street"
+    },
+    {
+      "address": "448 Washington Blvd NE"
+    },
+    {
+      "address": "4124 Apache Dr"
+    },
+    {
+      "address": "6622 Airport Way S #1430"
+    },
+    {
+      "address": "235 Prospect Valley Road SE"
+    },
+    {
+      "address": "142 E Barrel Hoop Circle #4A"
+    },
+    {
+      "address": "441 SW Río de la Plata Drive"
+    },
+    {
+      "address": "3400 E Del Ray Place"
+    },
+    {
+      "address": "3373 NW Martin Luther King Jr Blvd"
+    },
+    {
+      "address": "1292 Orchard Terrace"
+    }
+  ]
+}

--- a/static/fake_data.json
+++ b/static/fake_data.json
@@ -182,53 +182,21 @@
     }
   ],
   "addresses": [
-    {
-      "address": "7 Q St"
-    },
-    {
-      "address": "17 8th St"
-    },
-    {
-      "address": "9 W 2nd Ave"
-    },
-    {
-      "address": "148 S East St"
-    },
-    {
-      "address": "412 Avenue M #3E"
-    },
-    {
-      "address": "10642 N Second Ave"
-    },
-    {
-      "address": "812 S 129th Street"
-    },
-    {
-      "address": "448 Washington Blvd NE"
-    },
-    {
-      "address": "4124 Apache Dr"
-    },
-    {
-      "address": "6622 Airport Way S #1430"
-    },
-    {
-      "address": "235 Prospect Valley Road SE"
-    },
-    {
-      "address": "142 E Barrel Hoop Circle #4A"
-    },
-    {
-      "address": "441 SW Río de la Plata Drive"
-    },
-    {
-      "address": "3400 E Del Ray Place"
-    },
-    {
-      "address": "3373 NW Martin Luther King Jr Blvd"
-    },
-    {
-      "address": "1292 Orchard Terrace"
-    }
+    "7 Q St",
+    "17 8th St",
+    "9 W 2nd Ave",
+    "148 S East St",
+    "412 Avenue M #3E",
+    "10642 N Second Ave",
+    "812 S 129th Street",
+    "448 Washington Blvd NE",
+    "4124 Apache Dr",
+    "6622 Airport Way S #1430",
+    "235 Prospect Valley Road SE",
+    "142 E Barrel Hoop Circle #4A",
+    "441 SW Río de la Plata Drive",
+    "3400 E Del Ray Place",
+    "3373 NW Martin Luther King Jr Blvd",
+    "1292 Orchard Terrace"
   ]
 }

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -87,7 +87,7 @@ class MilMoveProvider(DateProvider):
         Returns a safe street address as a string.
         """
         address = self.random_element(self.safe_data["addresses"])
-        return address["address"]
+        return address
 
 
 class MilMoveData:

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """ utils/fake_data.py is for Faker classes and functions to set up test data """
 import logging
+import json
 from typing import Optional
 from copy import deepcopy
 from datetime import datetime
-
 from faker import Faker
 from faker.providers.date_time import Provider as DateProvider  # extends BaseProvider
 
@@ -15,6 +15,16 @@ logger = logging.getLogger(__name__)
 
 class MilMoveProvider(DateProvider):
     """ Faker Provider class for sending back customized MilMove data. """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        with open("static/fake_data.json") as f:
+            self.safe_data = json.load(f)
+
+        self.current_name = {"first_name": "", "last_name": ""}
+        self.first_name_used = True
+        self.last_name_used = True
 
     def safe_phone_number(self):
         """
@@ -41,6 +51,44 @@ class MilMoveProvider(DateProvider):
         """
         return datetime.isoformat(self.date_time())
 
+    def set_safe_name(self):
+        """
+        Randomly selects a safe full name to use.
+        """
+        random_name = self.random_element(self.safe_data["names"])
+        self.first_name_used, self.last_name_used = False, False
+
+        self.current_name.update({"first_name": random_name["first_name"], "last_name": random_name["last_name"]})
+
+    def safe_first_name(self):
+        """
+        Returns a safe first name as a string.
+        """
+        if not self.first_name_used:
+            return self.current_name["first_name"]
+        else:
+            self.set_safe_name()
+            self.first_name_used = True
+            return self.current_name["first_name"]
+
+    def safe_last_name(self):
+        """
+        Returns a safe last name as a string.
+        """
+        if not self.last_name_used:
+            return self.current_name["last_name"]
+        else:
+            self.set_safe_name()
+            self.last_name_used = True
+            return self.current_name["last_name"]
+
+    def safe_street_address(self):
+        """
+        Returns a safe street address as a string.
+        """
+        address = self.random_element(self.safe_data["addresses"])
+        return address["address"]
+
 
 class MilMoveData:
     """ Base class to return fake data to use in MilMove endpoints. """
@@ -51,13 +99,12 @@ class MilMoveData:
         """
         self.fake = Faker()
         self.fake.add_provider(MilMoveProvider)
-
         self.data_types = {
-            DataType.FIRST_NAME: self.fake.first_name,  # TODO: replace with data from milmove fake address spreadsheet
-            DataType.LAST_NAME: self.fake.last_name,  # TODO: same ^
+            DataType.FIRST_NAME: self.fake.safe_first_name,
+            DataType.LAST_NAME: self.fake.safe_last_name,
             DataType.PHONE: self.fake.safe_phone_number,
             DataType.EMAIL: self.fake.safe_email,
-            DataType.STREET_ADDRESS: self.fake.street_address,  # TODO: same ^^
+            DataType.STREET_ADDRESS: self.fake.safe_street_address,
             DataType.CITY: self.fake.city,
             DataType.STATE: self.fake.state_abbr,
             DataType.POSTAL_CODE: self.fake.postalcode,
@@ -107,5 +154,4 @@ class MilMoveData:
         # Now we're going to use the override data that was passed in instead of any generated fake data for those
         # fields:
         data.update(overrides if overrides else {})
-
         return data

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -51,7 +51,7 @@ class MilMoveProvider(DateProvider):
         """
         return datetime.isoformat(self.date_time())
 
-    def set_safe_name(self):
+    def _set_safe_name(self):
         """
         Randomly selects a safe full name to use.
         """
@@ -64,30 +64,27 @@ class MilMoveProvider(DateProvider):
         """
         Returns a safe first name as a string.
         """
-        if not self.first_name_used:
-            return self.current_name["first_name"]
-        else:
-            self.set_safe_name()
-            self.first_name_used = True
-            return self.current_name["first_name"]
+        if self.first_name_used:
+            self._set_safe_name()
+
+        self.first_name_used = True
+        return self.current_name["first_name"]
 
     def safe_last_name(self):
         """
         Returns a safe last name as a string.
         """
-        if not self.last_name_used:
-            return self.current_name["last_name"]
-        else:
-            self.set_safe_name()
-            self.last_name_used = True
-            return self.current_name["last_name"]
+        if self.last_name_used:
+            self._set_safe_name()
+
+        self.last_name_used = True
+        return self.current_name["last_name"]
 
     def safe_street_address(self):
         """
         Returns a safe street address as a string.
         """
-        address = self.random_element(self.safe_data["addresses"])
-        return address
+        return self.random_element(self.safe_data["addresses"])
 
 
 class MilMoveData:


### PR DESCRIPTION
## Description

* This PR replaces Faker's generated data for first name, last name, and street address, with MilMove's approved safe fake data.
* Data from spreadsheet is stored in `static/fake_data.json`


## Reviewer Notes

* The createMoveTaskOrder endpoint isn't dynamically creating data yet, so you won't be able to use it to verify
* Use GET /move-task-orders and review the newly added mto_shipments to see the fake data
  * Addresses -> street_address_1, etc.
  * Names -> Agents

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
# in /mymove
make dev_db_e2e_populate
make server_run

# in /milmove-load-testing
make load_test_prime
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2970) for this change.