### PR TITLE
MB-2714 Add update_mto_shipment task

### DIFF
--- a/locustfiles/prime.py
+++ b/locustfiles/prime.py
@@ -27,6 +27,7 @@ class PrimeUser(MilMoveHostMixin, HttpUser):
 
     wait_time = between(0.25, 9)  # the time period to wait in between tasks (in seconds, accepts decimals and 0)
     tasks = {PrimeTasks: 1}  # the set of tasks to be executed and their relative weight
+    weight = 5
 
 
 class SupportUser(MilMoveHostMixin, HttpUser):
@@ -43,3 +44,4 @@ class SupportUser(MilMoveHostMixin, HttpUser):
 
     wait_time = between(0.25, 9)
     tasks = {SupportTasks: 1}
+    weight = 1


### PR DESCRIPTION
## Description

This PR adds a task to hit the `updateMTOShipment` endpoint to the `PrimeTasks` task set. It uses a rudimentary process to pass shipment IDs and eTags from the `create_mto_shipment` task to this one, and populates most of the payload with fake generated data. Some overrides are implemented because those fields require more complexity and need the architecture from [MB-3244](https://dp3.atlassian.net/browse/MB-3244) to be successful.

## Reviewer Notes

**KEEP IN MIND:** The Support API task `create_move_task_order` is currently broken due to changes from the consolidation of the MilMove database. There is a ticket in the backlog to fix this, and it won't be addressed in this ticket.

## Setup

Run the server in `mymove`:

```sh
make db_dev_e2e_populate && make server_run
```

Then in `milmove_load_testing`, rebuild the project and run the load tests:

```sh
$ make rebuild
$ . .venv/bin/activate
(.venv) $ locust -f locustfiles/prime.py --tags mtoShipment --host local PrimeUser
```

All tasks except the `create_move_task_order` task should have mostly 200 response codes.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2714) for this change.
