### PR TITLE
MB-3398 Support API: Fix load testing task for createMoveTaskOrder endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,9 +434,8 @@ parser.get_definition(name="MoveTaskOrder")
 
 * `generate_fake_request`: Takes in the endpoint `path` and `method` and returns a JSON-ready dictionary with the fields
 and fake data for the request. Uses the `faker` library to generate the data. Can optionally accept a dictionary of
-`overrides` for top-level fields that should have specific fields, a dictionary of `nested_overrides` for fields in
-child objects that should have specific data, or a boolean `require_all` that indicates that all fields should be
-filled, even if not required.
+`overrides` for any fields that need to have specific values set, or a boolean `require_all` that indicates that all
+fields should be filled, even if not required.
 
 ```python
 parser.generate_fake_request(path="/mto-service-items", method="post", overrides={"modelType": "MTOServiceItemDDSFIT"})

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -30,9 +30,12 @@ def check_response(response, task_name="Task", request=None):
         return None, False
 
     if not str(response.status_code).startswith("2"):
-        logger.error(f"⚠️ {json_response}")
+        logger.error(f"⚠️\n{json.dumps(json_response, indent=4)}")
         if request:
-            logger.error(f"Request data: {request}")
+            try:
+                logger.error(f"Request data:\n{json.dumps(request, indent=4)}")
+            except (json.JSONDecodeError, TypeError):
+                logger.error(f"Request data:\n{request}")
 
         return json_response, False
 

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -38,11 +38,11 @@ class ParserTaskMixin:
         if not hasattr(self.user, "parser"):
             raise ImplementationError("The user for a TaskSet using ParserTaskSet mixin must have a parser attribute.")
 
-    def fake_request(self, path, method, overrides=None, nested_overrides=None, require_all=False):
+    def fake_request(self, path, method, overrides=None, require_all=False):
         """
         Wraps the parser's generate_fake_request method for ease of use.
         """
-        return self.user.parser.generate_fake_request(path, method, overrides, nested_overrides, require_all)
+        return self.user.parser.generate_fake_request(path, method, overrides, require_all)
 
 
 class LoginTaskSet(TaskSet):

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -1,8 +1,44 @@
 # -*- coding: utf-8 -*-
 """ tasks/base.py is for code used internally within the tasks package. """
+import logging
+import json
+
 from locust import TaskSet
 
 from utils.base import ImplementationError
+
+logger = logging.getLogger(__name__)
+
+
+def check_response(response, task_name="Task", request=None):
+    """
+    Logs the status code from the response and converts it from JSON into a python dictionary we can work with. If the
+    status code wasn't a success (2xx), it can also log any request data that was sent in for the sake of debugging.
+    Returns the dictionary representation of the response content and a boolean indicating success or failure.
+
+    :param response: HTTP response object
+    :param task_name: str, optional name of the tasks
+    :param request: any, optional data to print for debugging a failed response
+    :return: tuple(dict, bool)
+    """
+    logger.info(f"ℹ️ {task_name} status code: {response.status_code}")
+
+    try:
+        json_response = json.loads(response.content)
+    except (json.JSONDecodeError, TypeError):
+        logger.exception("Non-JSON response.")
+        return None, False
+
+    if not str(response.status_code).startswith("2"):
+        logger.error(f"⚠️ {json_response}")
+        if request:
+            logger.error(f"Request data: {request}")
+
+        return json_response, False
+
+    logger.info(f"ℹ️ {task_name} successfully completed!")
+
+    return json_response, True
 
 
 class CertTaskMixin:

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -171,14 +171,20 @@ class SupportTasks(ParserTaskMixin, CertTaskMixin, TaskSet):
                 "rank": "E-6",
                 "destinationDutyStationID": "71b2cafd-7396-4265-8225-ff82be863e01",
                 "originDutyStationID": "1347d7f3-2f9a-44df-b3a5-63941dd55b34",
+                "uploadedOrdersID": "f4960bdb-ada6-48dc-b53d-a5961644932e",
+                "ordersType": "GHC",
+                "reportByDate": "2020-01-01",
+                "status": "SUBMITTED",
+                "issueDate": "2020-01-01",
             },
         }
+
         headers = {"content-type": "application/json"}
         resp = self.client.post(
             support_path("/move-task-orders"), data=json.dumps(payload), headers=headers, **self.user.cert_kwargs
         )
-
         json_body, success = check_response(resp, "Create MTO", payload)
+
         if not success:
             return  # no point continuing if it didn't work out
 

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -5,7 +5,7 @@ import json
 
 from locust import tag, task, TaskSet
 
-from utils.constants import TEST_PDF
+from utils.constants import TEST_PDF, ZERO_UUID
 from .base import CertTaskMixin, ParserTaskMixin
 
 logger = logging.getLogger(__name__)
@@ -74,7 +74,7 @@ class PrimeTasks(ParserTaskMixin, CertTaskMixin, TaskSet):
             "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
             "mtoShipmentID": "475579d5-aaa4-4755-8c43-c510381ff9b5",
         }
-        payload = self.fake_request("/mto-service-items", "post", overrides=overrides, nested_overrides=overrides)
+        payload = self.fake_request("/mto-service-items", "post", overrides=overrides)
 
         headers = {"content-type": "application/json"}
         resp = self.client.post(
@@ -85,8 +85,14 @@ class PrimeTasks(ParserTaskMixin, CertTaskMixin, TaskSet):
     @tag("mtoShipment", "createMTOShipment")
     @task
     def create_mto_shipment(self):
-        overrides = {"moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e", "mtoServiceItems": []}
-        payload = self.fake_request("/mto-shipments", "post", overrides=overrides, nested_overrides=overrides)
+        overrides = {
+            "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
+            "agents": {"id": ZERO_UUID, "mtoShipmentID": ZERO_UUID},
+            "pickupAddress": {"id": ZERO_UUID},
+            "destinationAddress": {"id": ZERO_UUID},
+            "mtoServiceItems": [],
+        }
+        payload = self.fake_request("/mto-shipments", "post", overrides=overrides)
         payload.pop("primeEstimatedWeight", None)  # keeps the update endpoint happy
 
         headers = {"content-type": "application/json"}

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -6,7 +6,7 @@ import json
 from locust import tag, task, TaskSet
 
 from utils.constants import TEST_PDF, ZERO_UUID
-from .base import CertTaskMixin, ParserTaskMixin
+from .base import check_response, CertTaskMixin, ParserTaskMixin
 
 logger = logging.getLogger(__name__)
 
@@ -17,37 +17,6 @@ def prime_path(url):
 
 def support_path(url):
     return f"/support/v1{url}"
-
-
-def check_response(response, task_name="Task", request=None):
-    """
-    Logs the status code from the response and converts it from JSON into a python dictionary we can work with. If the
-    status code wasn't a success (2xx), it can also log any request data that was sent in for the sake of debugging.
-    Returns the dictionary representation of the response content and a boolean indicating success or failure.
-
-    :param response: HTTP response object
-    :param task_name: str, optional name of the tasks
-    :param request: any, optional data to print for debugging a failed response
-    :return: tuple(dict, bool)
-    """
-    logger.info(f"ℹ️ {task_name} status code: {response.status_code}")
-
-    try:
-        json_response = json.loads(response.content)
-    except (json.JSONDecodeError, TypeError):
-        logger.exception("Non-JSON response.")
-        return None, False
-
-    if not str(response.status_code).startswith("2"):
-        logger.error(f"⚠️ {json_response}")
-        if request:
-            logger.error(f"Request data: {request}")
-
-        return json_response, False
-
-    logger.info(f"ℹ️ {task_name} successfully completed!")
-
-    return json_response, True
 
 
 @tag("prime")

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -14,6 +14,8 @@ PRIME_CERT_KWARGS = {"cert": (LOCAL_MTLS_CERT, LOCAL_MTLS_KEY), "verify": False}
 ARRAY_MIN = 1
 ARRAY_MAX = 5
 
+ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+
 
 class MilMoveEnv(ListEnum):
     LOCAL = "local"

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -5,6 +5,7 @@ import json
 from typing import Optional
 from copy import deepcopy
 from datetime import datetime
+
 from faker import Faker
 from faker.providers.date_time import Provider as DateProvider  # extends BaseProvider
 

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -208,7 +208,7 @@ class ObjectField(BaseAPIField):
         overrides = {} if not overrides else overrides
 
         if self.name in overrides:
-            overrides = overrides[self.name]
+            overrides = overrides[self.name] or {}
 
         d_value = self.generate_discriminator_value(faker, overrides)
         if self.discriminator and d_value:

--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -100,15 +100,14 @@ class APIParser:
         """
         return self.parser.specification["definitions"].get(name)
 
-    def generate_fake_request(self, path, method, overrides=None, nested_overrides=None, require_all=False):
+    def generate_fake_request(self, path, method, overrides=None, require_all=False):
         """
         Generates a request body filled with fake data to use with a specific endpoint in the API. Requires the endpoint
-        path and method. Optionally takes in top level overrides and nested overrides.
+        path and method. Optionally takes in overrides and a bool indicating if all fields should be required or not.
 
         :param path: str
         :param method: str
         :param overrides: dict, optional
-        :param nested_overrides: dict, optional
         :param require_all: bool, optional
         :return: dict
         """
@@ -116,7 +115,7 @@ class APIParser:
         if not request_body:
             request_body = self._process_request_body(path, method)
 
-        fake_request = request_body.generate_fake_data(self.milmove_data, overrides, nested_overrides, require_all)
+        fake_request = request_body.generate_fake_data(self.milmove_data, overrides, require_all)
         # Hook method for custom post-data generation validation:
         self._custom_request_validation(path, method, fake_request)
 
@@ -372,11 +371,11 @@ class PrimeAPIParser(APIParser):
 
     api_file = "https://raw.githubusercontent.com/transcom/mymove/master/swagger/prime.yaml"
 
-    def generate_fake_request(self, path, method, overrides=None, nested_overrides=None, require_all=True):
+    def generate_fake_request(self, path, method, overrides=None, require_all=True):
         """
         Overrides method so that require_all defaults to True. TODO remove when API discrepancies are fixed
         """
-        return super().generate_fake_request(path, method, overrides, nested_overrides, True)
+        return super().generate_fake_request(path, method, overrides, True)
 
     def _custom_field_validation(self, field, object_def):
         """


### PR DESCRIPTION
## Description

This PR changes the hardcoded payload for the task `create_move_task_order` so that it functions with the changes after consolidating the DB. It also reworks the way overrides work so that it's a little more intuitive. There's also some general clean up and fixing of other issues (such as the `create_mto_shipment` task). 

## Reviewer Notes

You will need to checkout the `sw-mb-3398-fix-create-mto` branch in the `mymove` repo in order to test these changes. Here is the PR: https://github.com/transcom/mymove/pull/4515

To run this against the changes to the YAML for the support and prime APIs, you may need to change the hardcoded url in `PrimeAPIParser` and `SupportAPIParser` to use the correct branch as well (instead of master). You can reasonably test without doing this however, and it will let you see that some requests to `create_mto_shipment` will fail because they have too many agents!

## Setup

In your `mymove` project, checkout `sw-mb-3398-fix-create-mto` and run:

```sh
make db_dev_e2e_populate && make server_run
```

Next, in your `milmove_load_testing` directory, please follow the instructions in the README to set up your environment. Then run:

```sh
make load_test_prime
```

Or:

```sh
. .venv/bin/activate && locust -f locustfiles/prime.py --host local
```

Then navigate to http://localhost:8089/, choose a random number of users and a hatch rate, then run the load tests. Most responses for all endpoints should be successful.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3398) for this change.
