### PR TITLE
MB-3398 Add new uploadedOrdersID that's actually static

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -171,7 +171,7 @@ class SupportTasks(ParserTaskMixin, CertTaskMixin, TaskSet):
                 "rank": "E-6",
                 "destinationDutyStationID": "71b2cafd-7396-4265-8225-ff82be863e01",
                 "originDutyStationID": "1347d7f3-2f9a-44df-b3a5-63941dd55b34",
-                "uploadedOrdersID": "f4960bdb-ada6-48dc-b53d-a5961644932e",
+                "uploadedOrdersID": "c26421b0-e4c3-446b-88f3-493bb25c1756",
                 "ordersType": "GHC",
                 "reportByDate": "2020-01-01",
                 "status": "SUBMITTED",


### PR DESCRIPTION
## Description

This PR updates the fake payload for the `create_move_task_order` Support task to use a new static ID for the required `uploadedOrdersID` field. This change depends on [this PR](https://github.com/transcom/mymove/pull/4563) in the mymove repo to be merged.

## Setup

Checkout the `sw-add-static-uuid-to-test-doc` branch in the mymove project and run the server:

```sh
make db_dev_e2e_populate && make server_run
```

Then test load testing with `make load_test_prime` and verify that all endpoints have mostly 2xx response codes, and in particular make sure that the `POST | /support/v1/move-task-orders` request is mostly successful.

## References

* Required PR: https://github.com/transcom/mymove/pull/4563
