### PR TITLE
MB-3244 Add architecture to save data for use in multiple tasks

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -22,10 +22,10 @@ def support_path(url):
 
 class PrimeDataTaskMixin:
     """
-
+    TaskSet mixin used to store data from the Prime API during load testing so that it can be passed around and reused.
     """
 
-    DATA_LIST_MAX = 25
+    DATA_LIST_MAX = 50
     prime_data = {
         PrimeObjects.MOVE_TASK_ORDER: [],
         PrimeObjects.MTO_SHIPMENT: [],
@@ -34,14 +34,22 @@ class PrimeDataTaskMixin:
     }  # data stored will be shared among class instances thanks to mutable dict
 
     def get_random_data(self, object_key):
-        """  """
+        """ Given a PrimeObjects value, returns a random data element from the list. """
         data_list = self.prime_data[object_key]
 
         if len(data_list) > 0:  # otherwise we return None
             return random.choice(data_list)
 
     def set_prime_data(self, object_key, object_data):
-        """  """
+        """
+        Sets data to the list for the object key provided. Also checks if the list is already at the max number of
+        elements, and if so, it randomly removes 1 to MAX number of elements so that the cycle can start again (and so
+        we don't hog too much memory).
+
+        :param object_key: PrimeObjects
+        :param object_data: JSON/dict
+        :return: None
+        """
         data_list = self.prime_data[object_key]
 
         if len(data_list) >= self.DATA_LIST_MAX:
@@ -51,7 +59,7 @@ class PrimeDataTaskMixin:
         data_list.append(object_data)
 
     def replace_prime_data(self, object_key, old_data, new_data):
-        """  """
+        """ Given an object key, it removes a value in the in list with a new updated value. """
         data_list = self.prime_data[object_key]
 
         try:

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -90,3 +90,12 @@ class DataType(ListEnum):
     ENUM = "enum"
     ARRAY = "array"
     OBJECT = "object"
+
+
+class PrimeObjects(ListEnum):
+    """ Constants representing the objects used in the Prime API. """
+
+    MOVE_TASK_ORDER = "mto"
+    MTO_SHIPMENT = "mtoShipment"
+    MTO_SERVICE_ITEM = "mtoServiceItem"
+    PAYMENT_REQUEST = "paymentRequest"


### PR DESCRIPTION
## Description

This PR adds a mixin to the PrimeTasks and SupportTasks classes that saves the data from the tasks in a list for later use by other tasks. The current flow is random, but this class can be built upon later to set a prescribed order for the data usage. 

One thing to keep in mind is that because of the random and quick nature of these updates, you will see more 412 (stale request) and 409 (conflict) responses. This is acceptable, and possibly even ideal from a natural load testing perspective, as long as there are more successful requests for those endpoints. 


## Setup

Run the server in your `mymove` directory (and don't forget to migrate the db if you haven't in a while!):

```sh
make db_dev_e2e_populate && server_run
```

Rebuild or clean the `milmove_load_testing` repo if you need to, and then run:

```sh
make load_test_prime
```

There should be 8 tasks in the list (the `fetch_mto_updates` task can take a _very_ long time if you have a good amount of data in your database, and it may not pop up for a while). Check that most response codes are 200. Also, it would be good to peak into your database and double check that a variety of load testing objects are being referenced.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3244) for this change.
