### PR TITLE
MB-3687 Add handling for array of service items in prime data

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -56,7 +56,12 @@ class PrimeDataTaskMixin:
             num_to_delete = random.randint(1, self.DATA_LIST_MAX)
             del data_list[:num_to_delete]
 
-        data_list.append(object_data)
+        # Some creation endpoint auto-create multiple objects and return an array,
+        # but each object in the array should still be considered individually here:
+        if isinstance(object_data, list):
+            data_list.extend(object_data)
+        else:
+            data_list.append(object_data)
 
     def replace_prime_data(self, object_key, old_data, new_data):
         """ Given an object key, it removes a value in the in list with a new updated value. """


### PR DESCRIPTION
## Description

The ticket ([MB-3687](https://dp3.atlassian.net/browse/MB-3687)) to change the `CreateMTOServiceItem` endpoint to return an array of service items caused an issue with the way the task in load testing was handling that endpoint. This PR fixes that up.

## Reviewer Notes

The `CreatePaymentRequest` endpoint sends back a lot of 500 errors - this is because basically every error returned from that endpoint is a 500 (as opposed to 409, 412, etc). There is some discovery that needs to happen to smooth out the responses there.

## Setup

First set up and run your MilMove server (in the `mymove` directory)

```sh
make db_dev_e2e_populate && make server_run
```

Start up load testing for the Prime API (and run `make rebuild` if you might have out of date requirements):

```sh
make load_test_prime
```

Open http://localhost:8089 and select a random number of users and a hatch rate. Wait for a bit and then check that you see 7 tasks with mostly 200 response codes (except the `CreatePaymentRequest` task) and no exceptions.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3687) for this change.
