### PR TITLE
MB-3290 Add updateMTOShipmentStatus task

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -251,7 +251,7 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
 
         # Generate fake payload based on the endpoint's required fields
         payload = self.fake_request("/mto-shipments/{mtoShipmentID}/status", "patch")
-        print(payload)
+
         headers = {"content-type": "application/json", "If-Match": mto_shipment["eTag"]}
 
         resp = self.client.patch(

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -288,7 +288,7 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
 
         resp = self.client.patch(
             support_path(f"/mto-shipments/{mto_shipment['id']}/status"),
-            name=support_path("/mto-shipments/:mtoShipmentID/status"),
+            name=support_path("/mto-shipments/{mtoShipmentID}/status"),
             data=json.dumps(payload),
             headers=headers,
             **self.user.cert_kwargs,


### PR DESCRIPTION
## Description

* Adds task to `supportTasks` for updateMTOShipmentStatus.
* Includes additional `status: submitted` in creating MTOs to work around an issue with the state of a move when creating mtoServiceItems.

## Setup

```sh
make load_test_prime
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3290) for this change.
