### PR TITLE
[MB-3289] Adds task for updateMTOServiceItemStatus handler.

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -361,7 +361,7 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
 
         resp = self.client.patch(
             support_path(f"/service-items/{mto_service_item['id']}/status"),
-            name=support_path("/service-items/:mtoShipmentID/status"),
+            name=support_path("/service-items/{mtoShipmentID}/status"),
             data=json.dumps(payload),
             headers=headers,
             **self.user.cert_kwargs,

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -351,17 +351,12 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     @tag(PrimeObjects.MTO_SERVICE_ITEM.value, "updateMTOServiceItemStatus")
     @task
     def update_mto_service_item_status(self):
-        mto_shipment = self.get_random_data(PrimeObjects.MTO_SHIPMENT)
+        mto_service_item = self.get_random_data(PrimeObjects.MTO_SERVICE_ITEM)
         # if we don't have an mto shipment we can't run this task
-        if not mto_shipment:
-            return
-
-        # if we don't have any service items created for mto shipment can't run this task
-        if mto_shipment.get("mtoServiceItems") is None:
+        if not mto_service_item:
             return
 
         payload = self.fake_request("/service-items/{mtoServiceItemID}/status", "patch")
-        mto_service_item = mto_shipment["mtoServiceItems"][0]
         headers = {"content-type": "application/json", "If-Match": mto_service_item["eTag"]}
 
         resp = self.client.patch(
@@ -375,6 +370,4 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
         mto_service_item_data, success = check_response(resp, "Update MTO service item status")
 
         if success:
-            new_shipment = deepcopy(mto_shipment)
-            new_shipment["mtoServiceItems"][0] = mto_service_item_data
-            self.replace_prime_data(PrimeObjects.MTO_SHIPMENT, mto_shipment, new_shipment)
+            self.replace_prime_data(PrimeObjects.MTO_SERVICE_ITEM, mto_service_item, mto_service_item_data)

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -366,7 +366,7 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
 
         resp = self.client.patch(
             support_path(f"/service-items/{mto_service_item['id']}/status"),
-            name=support_path("/mto-shipments/:mtoShipmentID/status"),
+            name=support_path("/service-items/:mtoShipmentID/status"),
             data=json.dumps(payload),
             headers=headers,
             **self.user.cert_kwargs,


### PR DESCRIPTION
## Description

This PR adds `updateMTOServiceItemStatus` handler to the `SupportTasksSet` for load testing integration. 

## Reviewer Notes

See inline comments. 

## Setup

1. Start and run `mymove` Prime API.
```sh
mylaptop ~ %: cd /mymove
mylaptop ~ %: make server_run
```

2. Load end to end data depended for load test. 
```sh
mylaptop mymove  %: make db_dev_e2e_populate
```

3. Start Locust load testing framework and run `updateMTOServiceItemStatus` test. 
```sh
mylaptop ~ %: cd /milmove_load_testing
mylaptop milmove_load_testing  %: locust -f locustfiles/prime.py --host local --headless -u 5 -r 5
```

4. After starting load tests, ensure handler responds with `200` status code, specifically for `PATCH /prime/v1/mto-shipments/:mtoShipmentID/status`.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3289) for this change.
