### PR TITLE
MB-5820 Load testing UpdateMTOServiceItem

### DIFF
--- a/tasks/base.py
+++ b/tasks/base.py
@@ -33,9 +33,11 @@ def check_response(response, task_name="Task", request=None):
         logger.error(f"⚠️\n{json.dumps(json_response, indent=4)}")
         if request:
             try:
-                logger.error(f"Request data:\n{json.dumps(request, indent=4)}")
+                logger.error(
+                    f"Request data:\n{response.request.method} {response.request.url}\n{json.dumps(request, indent=4)}"
+                )
             except (json.JSONDecodeError, TypeError):
-                logger.error(f"Request data:\n{request}")
+                logger.error(f"Request data:\n{response.request.method} {response.request.url}\n{request}")
 
         return json_response, False
 

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -300,7 +300,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
             logger.error("⛔️ update_mto_service_item recvd mtoServiceItem without reServiceCode \n{mto_service_item}")
             return
 
-        if re_service_code != "DDDSIT" and re_service_code != "DOPSIT":
+        if re_service_code not in ["DDDSIT", "DOPSIT"]:
             logging.info(
                 "update_mto_service_item recvd mtoServiceItem from store. Discarding because reServiceCode not in [DDDSIT, DOPSIT]"
             )

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -346,7 +346,6 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     def create_move_task_order(self):
         payload = {
             "contractorId": "5db13bb4-6d29-4bdb-bc81-262f4513ecf6",
-            "status": "SUBMITTED",
             "moveOrder": {
                 "customer": {
                     "firstName": "Christopher",


### PR DESCRIPTION
## Description

This ticket was to add a task for the endpoint updateMTOServiceItem. This endpoint needs DDDSIT or DOPSIT items to update. Those items are created when you create a DOFSIT or DDFSIT item as those create a trio of SIT items. 

So this code adds tasks to request DOFSIT or DDFSIT creation, and to also request updating the DDDSIT or DOPSIT items. 

Some fixes that went in this code
- missing agents check
- log url and method when we have an error response
- make createMTOServiceItems accept and apply overrides
- update response strings to use the operationID for consistency

## Setup
You need a lot of requests for there to be enough to create the specific types you want. 

- run Locust with make load_test_prime
- In the locust load test, select 50/10 for number of "users to simulate" and for "swarm rate".
- Check to see how many failures there are.

Then watch the Locust statistics page and wait for at least a few hits on the `/prime/v1/mto-service-items/:mtoServiceItemID` patch command. 

Then check your logs and see if you can find some successful updateMTOServiceItem calls. Note there is a different endpoint called updateMTOServiceItemStatus. 

You may see the following log which is okay.
```
update_mto_service_item recvd mtoServiceItem from store. Discarding because reServiceCode not in [DDDSIT, DOPSIT]
```

Since the logs are hard to read, here are some things to check for
* [ ] Did you catch some successful hits to the endpoint?
* [ ] Do the failures make sense? 
* [ ] 500s are no good, if you catch them, add a ticket against milmove with the logs from the server. 

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?


## References

* [MB-5820 Prime API: Load Testing - UpdateMTOServiceItem](https://dp3.atlassian.net/browse/MB-5820)

