### PR TITLE
MB-5757 Add a Docker container to run load testing locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8
+
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install -r /app/requirements.txt
+
+EXPOSE 8089 5557
+
+ENTRYPOINT ["locust"]

--- a/Makefile
+++ b/Makefile
@@ -96,14 +96,17 @@ load_test_milmove: clean ensure_venv  ## Run load testing on the MilMove app
 	open http://localhost:8089
 	locust -f locustfiles/milmove.py --host local
 
-.PHONY: load_test_local_docker
-load_test_local_docker: clean  ## Run load testing on the Prime API in local using a Docker container
-	open http://localhost:8089
+.PHONY: local_docker_build
+local_docker_build: clean  ## Build a Docker container to run load testing locally
 	docker-compose -f docker-compose.local.yaml build
+
+.PHONY: local_docker_load_test
+local_docker_load_test: ## Run load testing on the Prime API in local using a Docker container
+	open http://localhost:8089
 	docker-compose -f docker-compose.local.yaml up
 
-.PHONY: stop_local_docker
-stop_local_docker:  ## Shutdown any active local docker containers with docker-compose
+.PHONY: local_docker_down
+local_docker_down:  ## Shutdown any active local docker containers with docker-compose
 	docker-compose -f docker-compose.local.yaml down
 
 default: help

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,14 @@ load_test_milmove: clean ensure_venv  ## Run load testing on the MilMove app
 	open http://localhost:8089
 	locust -f locustfiles/milmove.py --host local
 
+.PHONY: load_test_local_docker
+load_test_local_docker: clean  ## Run load testing on the Prime API in local using a Docker container
+	open http://localhost:8089
+	docker-compose -f docker-compose.local.yaml build
+	docker-compose -f docker-compose.local.yaml up
+
+.PHONY: stop_local_docker
+stop_local_docker:  ## Shutdown any active local docker containers with docker-compose
+	docker-compose -f docker-compose.local.yaml down
+
 default: help

--- a/Makefile
+++ b/Makefile
@@ -82,17 +82,17 @@ lint: ensure_venv  ## Run linting tests
 	flake8 .
 
 .PHONY: load_test_prime
-load_test_prime: ensure_venv  ## Run load testing on the Prime API
+load_test_prime: clean ensure_venv  ## Run load testing on the Prime API
 	open http://localhost:8089
 	locust -f locustfiles/prime.py --host local
 
 .PHONY: load_test_office
-load_test_office: ensure_venv  ## Run load testing on the Office app
+load_test_office: clean ensure_venv  ## Run load testing on the Office app
 	open http://localhost:8089
 	locust -f locustfiles/office.py --host local
 
 .PHONY: load_test_milmove
-load_test_milmove: ensure_venv  ## Run load testing on the MilMove app
+load_test_milmove: clean ensure_venv  ## Run load testing on the MilMove app
 	open http://localhost:8089
 	locust -f locustfiles/milmove.py --host local
 

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ load_test_milmove: clean ensure_venv  ## Run load testing on the MilMove app
 local_docker_build: clean  ## Build a Docker container to run load testing locally
 	docker-compose -f docker-compose.local.yaml build
 
-.PHONY: local_docker_load_test
-local_docker_load_test: ## Run load testing on the Prime API in local using a Docker container
+.PHONY: local_docker_up
+local_docker_up: ## Run load testing on the Prime API in local using a Docker container
 	open http://localhost:8089
 	docker-compose -f docker-compose.local.yaml up
 

--- a/README.md
+++ b/README.md
@@ -138,14 +138,13 @@ In order to enable `pyenv` to switch which version of Python you are using at an
 you will need to paste the following code to your shell's profile file (`~/.bash_profile`, `~/.bashrc`, `~/.zshrc`, etc):
 
 ```bash
-export PATH="{$HOME}/.pyenv/bin:{$PATH}"
+export PATH="$HOME/.pyenv/bin:$PATH"
 export PYENV_VIRTUALENV_DISABLE_PROMPT=1
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 ```
 
-Once you have modified and saved your profile file, you will need to resource your profile (where `<profile_file` is one
-of `~/.bash_profile`, `~/.bashrc`, etc):
+Once you have modified and saved your profile file, you will need to resource your profile:
 
 ```shell script
 source <profile_file>  # Or just restart your terminal

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ in the [LICENSE.txt](./LICENSE.txt) file in this repository.
          * [Setup: pre-commit](#setup-pre-commit)
          * [Setup: pyenv](#setup-pyenv)
          * [Setup: virtualenv](#setup-virtualenv)
+         * [Alternative Setup: Docker](#alternative-setup-docker)
          * [Troubleshooting](#troubleshooting)
       * [Running Load Tests](#running-load-tests)
          * [Setting up the local environment](#setting-up-the-local-environment)
@@ -45,7 +46,7 @@ in the [LICENSE.txt](./LICENSE.txt) file in this repository.
          * [Metrics](#metrics)
       * [References](#references)
 
-<!-- Added by: sandy, at: Wed Dec  9 15:32:07 CST 2020 -->
+<!-- Added by: sandy, at: Mon Dec 21 11:02:29 CST 2020 -->
 
 <!--te-->
 <!-- markdownlint-restore -->
@@ -214,6 +215,31 @@ make teardown
 ```
 
 Remember to recreate your virtual environment with `make venv` before attempting to continue development on the project.
+
+### Alternative Setup: Docker
+
+It is also possible to run load tests from within a Docker container, eliminating the need to set up a valid python
+environment. This requires Docker and `docker-compose` to be installed on your machine. Get them here:
+
+* [Get Docker](https://docs.docker.com/get-docker/)
+* [Install Docker Compose](https://docs.docker.com/compose/install/)
+
+To get your load testing Docker container up and running for the local environment, use the following commands:
+
+* `docker-compose -f docker-compose.local.yaml build`
+* `docker-compose -f docker-compose.local.yaml up`
+
+And when you are done with testing:
+
+* `docker-compose -f docker-compose.local.yaml build`
+
+You can also use the Makefile equivalents of these commands:
+
+* `make local_docker_build`
+* `make local_docker_up`
+* `make local_docker_down`
+
+As long as your local MilMove server is up and running, you are ready to run your tests!
 
 ### Troubleshooting
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+""" These imports are IMPORTant for Docker functionality """
+import tasks  # noqa
+import utils  # noqa

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  prime:
+    build:
+      context: .
+      network: host
+    ports:
+      - "8089:8089"
+      - "9443:9443"
+    entrypoint: ["python", "local_locust.py"]
+    # To use local_locust.py, we have to pass the locust flags in as a string that can be split to call the locust
+    # command as normal:
+    command: "'-f /app/locustfiles/prime.py --host local'"
+

--- a/local_locust.py
+++ b/local_locust.py
@@ -37,8 +37,19 @@ def update_docker_hosts():
 
 
 if __name__ == "__main__":
-    command = argparse.ArgumentParser(description="todo")
-    command.add_argument("locust_flags", type=str, help="todo arg")
+    command = argparse.ArgumentParser(
+        description="When executed, this command will update the /etc/hosts file of a running docker container with "
+        "the hostnames used in the MilMove, then it will execute the <locust> command. To run this script, "
+        "please put the command <python local_locust.py> as the CMD or ENTRYPOINT for a docker container. "
+        "Put the locust arguments you wish to include in one '<string>' argument for the command."
+    )
+    command.add_argument(
+        "locust_flags",
+        type=str,
+        help="All the locust arguments, as they would be written for "
+        "locust, should be written in this argument as one string. \n"
+        "Ex: '-f locustfiles/prime.py --host local'",
+    )
 
     args = command.parse_args()
     locust_flags = args.locust_flags.split()  # We will need the locust arguments as a list so we can invoke it later

--- a/local_locust.py
+++ b/local_locust.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+This script updates the /etc/hosts file from within a Docker container to contain the hostnames used in the MilMove
+project. ** It should only be run from within a container. **
+
+This script also executes a locust command immediately after updating the hosts file. All locust arguments and flags can
+be passed in as a string, but otherwise written with the usual syntax. Ex:
+
+$ python local_locust.py "-f /app/locustfiles/prime.py --host local"
+"""
+import os
+import socket
+import argparse
+
+# NOTE: we cannot use the constants file in this project for these values because this script must be able to run
+# independently.
+MILMOVE_HOSTNAMES = [
+    "milmovelocal",
+    "officelocal",
+    "primelocal",
+]
+
+
+def update_docker_hosts():
+    """
+    Grabs the Docker internal IP address using host.docker.internal, then adds lines to the /etc/hosts file with each of
+    the MilMove hostnames pointing towards this IP address.
+    :return: None
+    """
+    docker_internal_ip = socket.gethostbyname("host.docker.internal")
+
+    with open("/etc/hosts", "a") as docker_hosts:
+        docker_hosts.write("\n# MilMove Hosts added by local_locust.py\n")
+
+        for hostname in MILMOVE_HOSTNAMES:
+            docker_hosts.write(f"{docker_internal_ip} {hostname}\n")
+
+
+if __name__ == "__main__":
+    command = argparse.ArgumentParser(description="todo")
+    command.add_argument("locust_flags", type=str, help="todo arg")
+
+    args = command.parse_args()
+    locust_flags = args.locust_flags.split()  # We will need the locust arguments as a list so we can invoke it later
+    locust_flags.insert(0, "locust")
+
+    update_docker_hosts()
+
+    # Calls locust with the split arguments and stops execution of this (local_locust.py) command:
+    os.execvp("locust", locust_flags)

--- a/local_locust.py
+++ b/local_locust.py
@@ -46,9 +46,8 @@ if __name__ == "__main__":
     command.add_argument(
         "locust_flags",
         type=str,
-        help="All the locust arguments, as they would be written for "
-        "locust, should be written in this argument as one string. \n"
-        "Ex: '-f locustfiles/prime.py --host local'",
+        help="All the locust arguments, as they would be written for locust, should be written in this argument as one "
+        "string.\n  Ex: '-f locustfiles/prime.py --host local'",
     )
 
     args = command.parse_args()

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -95,7 +95,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     def create_mto_service_item(self, overrides=None):
         mto_shipment = self.get_random_data(PrimeObjects.MTO_SHIPMENT)
         if not mto_shipment:
-            if not self.user.env == MilMoveEnv.LOCAL:
+            if self.user.env != MilMoveEnv.LOCAL.value:
                 return  # we can't do anything else without a default value
 
             # default for local testing
@@ -152,7 +152,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     def create_mto_shipment(self):
         move_task_order = self.get_random_data(PrimeObjects.MOVE_TASK_ORDER)
         if not move_task_order:
-            if not self.user.env == MilMoveEnv.LOCAL:
+            if self.user.env != MilMoveEnv.LOCAL.value:
                 return  # we can't do anything else without a default value
 
             move_task_order = {"id": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e"}  # default for local testing
@@ -181,7 +181,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     def create_upload(self):
         payment_request = self.get_random_data(PrimeObjects.PAYMENT_REQUEST)
         if not payment_request:
-            if not self.user.env == MilMoveEnv.LOCAL:
+            if self.user.env != MilMoveEnv.LOCAL.value:
                 return  # we can't do anything else without a default value
 
             payment_request = {"id": "a2c34dba-015f-4f96-a38b-0c0b9272e208"}  # default for local testing
@@ -201,7 +201,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     def create_payment_request(self):
         service_item = self.get_random_data(PrimeObjects.MTO_SERVICE_ITEM)
         if not service_item:
-            if not self.user.env == MilMoveEnv.LOCAL:
+            if self.user.env != MilMoveEnv.LOCAL.value:
                 return  # we can't do anything else without a default value
 
             service_item = {

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -94,14 +94,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     def create_mto_service_item(self, overrides=None):
         mto_shipment = self.get_random_data(PrimeObjects.MTO_SHIPMENT)
         if not mto_shipment:
-            if self.user.env != MilMoveEnv.LOCAL.value:
-                return  # we can't do anything else without a default value
-
-            # default for local testing
-            mto_shipment = {
-                "id": "475579d5-aaa4-4755-8c43-c510381ff9b5",
-                "moveTaskOrderID": "99783f4d-ee83-4fc9-8e0c-d32496bef32b",
-            }
+            return
 
         overrides_local = {
             "moveTaskOrderID": mto_shipment["moveTaskOrderID"],
@@ -154,7 +147,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
             if self.user.env != MilMoveEnv.LOCAL.value:
                 return  # we can't do anything else without a default value
 
-            move_task_order = {"id": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e"}  # default for local testing
+            move_task_order = {"id": "ecbc2e6a-1b45-403b-9bd4-ea315d4d3d93"}  # default for local testing
 
         overrides = {
             "moveTaskOrderID": move_task_order["id"],
@@ -180,10 +173,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     def create_upload(self):
         payment_request = self.get_random_data(PrimeObjects.PAYMENT_REQUEST)
         if not payment_request:
-            if self.user.env != MilMoveEnv.LOCAL.value:
-                return  # we can't do anything else without a default value
-
-            payment_request = {"id": "a2c34dba-015f-4f96-a38b-0c0b9272e208"}  # default for local testing
+            return
 
         upload_file = {"file": open(TEST_PDF, "rb")}
 
@@ -200,13 +190,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     def create_payment_request(self):
         service_item = self.get_random_data(PrimeObjects.MTO_SERVICE_ITEM)
         if not service_item:
-            if self.user.env != MilMoveEnv.LOCAL.value:
-                return  # we can't do anything else without a default value
-
-            service_item = {
-                "id": "8a625314-1922-4987-93c5-a62c0d13f053",
-                "moveTaskOrderID": "da3f34cc-fb94-4e0b-1c90-ba3333cb7791",
-            }
+            return
 
         payload = {
             "moveTaskOrderID": service_item["moveTaskOrderID"],

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -29,7 +29,6 @@ class PrimeDataTaskMixin:
     DATA_LIST_MAX = 50
     prime_data = {
         PrimeObjects.MOVE_TASK_ORDER: [],
-        PrimeObjects.MTO_AGENT: [],  # Is it an array by default?
         PrimeObjects.MTO_SHIPMENT: [],
         PrimeObjects.MTO_SERVICE_ITEM: [],
         PrimeObjects.PAYMENT_REQUEST: [],
@@ -104,14 +103,14 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
                 "moveTaskOrderID": "99783f4d-ee83-4fc9-8e0c-d32496bef32b",
             }
 
-        overridesLocal = {
+        overrides_local = {
             "moveTaskOrderID": mto_shipment["moveTaskOrderID"],
             "mtoShipmentID": mto_shipment["id"],
         }
         # override local overrides with parameter overrides
         if overrides:
-            overridesLocal.update(overrides)
-        payload = self.fake_request("/mto-service-items", "post", overrides=overridesLocal)
+            overrides_local.update(overrides)
+        payload = self.fake_request("/mto-service-items", "post", overrides=overrides_local)
 
         headers = {"content-type": "application/json"}
         resp = self.client.post(
@@ -302,7 +301,8 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
 
         if re_service_code not in ["DDDSIT", "DOPSIT"]:
             logging.info(
-                "update_mto_service_item recvd mtoServiceItem from store. Discarding because reServiceCode not in [DDDSIT, DOPSIT]"
+                "update_mto_service_item recvd mtoServiceItem from store. Discarding because reServiceCode not in "
+                "[DDDSIT, DOPSIT]"
             )
             return
 

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -200,7 +200,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
 
         resp = self.client.post(
             prime_path(f"/payment-requests/{payment_request['id']}/uploads"),
-            name=prime_path("/payment-requests/:paymentRequestID/uploads"),
+            name=prime_path("/payment-requests/{paymentRequestID}/uploads"),
             files=upload_file,
             **self.user.cert_kwargs,
         )
@@ -252,7 +252,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
         headers = {"content-type": "application/json", "If-Match": mto_shipment["eTag"]}
         resp = self.client.put(
             prime_path(f"/mto-shipments/{mto_shipment['id']}"),
-            name=prime_path("/mto-shipments/:mtoShipmentID"),
+            name=prime_path("/mto-shipments/{mtoShipmentID}"),
             data=json.dumps(payload),
             headers=headers,
             **self.user.cert_kwargs,
@@ -350,7 +350,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
         headers = {"content-type": "application/json", "If-Match": mto_service_item["eTag"]}
         resp = self.client.patch(
             prime_path(f"/mto-service-items/{mto_service_item['id']}"),
-            name=prime_path("/mto-service-items/:mtoServiceItemID"),
+            name=prime_path("/mto-service-items/{mtoServiceItemID}"),
             data=json.dumps(payload),
             headers=headers,
             **self.user.cert_kwargs,
@@ -439,7 +439,7 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
 
         resp = self.client.patch(
             support_path(f"/move-task-orders/{move_task_order_id}/available-to-prime"),
-            name=support_path("/move-task-orders/:moveTaskOrderID/available-to-prime"),
+            name=support_path("/move-task-orders/{moveTaskOrderID}/available-to-prime"),
             headers=headers,
             **self.user.cert_kwargs,
         )


### PR DESCRIPTION
## Description

This PR's purpose is to add a Docker container that can run load testing and talk to our local mymove server. 

It also adds several small quality-of-life fixes throughout the code. Most prominently, it adds _back_ the `update_mto_shipment_address` task, which seems to have been deleted in a bad merge. 

## Setup

* First, make sure your local mymove server is running. To continue, you must also have `docker` and `docker-compose` installed on your system.

* Build the Docker container using either the Makefile command:

```sh
make local_docker_build
```

Or the docker-compose command:

```sh
docker-compose -f docker-compose.local.yaml build
```

* Once that process has completed, run the docker container using one of:

```sh
make local_docker_up
```

```sh
docker-compose -f docker-compose.local.yaml up
```

* Now you may navigate to http://0.0.0.0:8089 and run load tests to verify that they are working.

* Once you are done with your testing, run one of:

```sh
make local_docker_down
```

```sh
docker-compose -f docker-compose.local.yaml down
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5757) for this change.
