### PR TITLE
Makes InsecureRequestWarning trigger only once

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -2,3 +2,8 @@
 from .office import OfficeTasks  # noqa
 from .milmove import MilMoveTasks  # noqa
 from .prime import PrimeTasks, SupportTasks  # noqa
+import warnings
+import requests
+
+# Sets warning to trigger once rather than on each instance
+warnings.simplefilter("once", requests.packages.urllib3.exceptions.InsecureRequestWarning)


### PR DESCRIPTION
## Description

Sets InsecureRequestWarning to trigger only once vs each time. 
Definitely upto you if you think we should do this. 
Con - easier to miss the warning since it's triggered only once
Pro - if we don't do it, easier to miss actual errors in the log due to the flood of warnings.

## Setup

Run any load testing, check for warning to appear once. 

```
/Users/shimona/.pyenv/versions/3.8.3/envs/locust-venv/lib/python3.8/site-packages/urllib3/connectionpool.py:1013: 
InsecureRequestWarning: Unverified HTTPS request is being made to host 'primelocal'. Adding certificate verification is 
strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
```

