### PR TITLE
MB-3240 Added updatePaymentRequestStatus task to load testing

### DIFF
--- a/tasks/base.py
+++ b/tasks/base.py
@@ -30,7 +30,7 @@ def check_response(response, task_name="Task", request=None):
         return None, False
 
     if not str(response.status_code).startswith("2"):
-        logger.error(f"⚠️\n{json.dumps(json_response, indent=4)}")
+        logger.error(f"⚠️ {task_name} failed.\n{json.dumps(json_response, indent=4)}")
         if request:
             try:
                 logger.error(

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -410,6 +410,7 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
                     "agency": "MARINES",
                     "email": "swinglehurst@example.com",
                     "rank": "E_3",
+                    "dodID": "4586736251",
                 },
                 "entitlement": {"nonTemporaryStorage": False, "totalDependents": 47},
                 "orderNumber": "32",

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -136,30 +136,6 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
         if success:
             self.set_prime_data(PrimeObjects.MTO_SERVICE_ITEM, resp)
 
-    @tag(PrimeObjects.MTO_SERVICE_ITEM.value, "createMTOServiceItemDestSIT")
-    @task
-    def create_mto_service_item_dest_sit(self):
-        # This function ensures some destination SIT service items get requested.
-        # DDFSIT requests create the trio of dest SIT items that are needed for update_mto_service_item to function.
-        overrides = {
-            "reServiceCode": "DDFSIT",
-            "modelType": "MTOServiceItemDestSIT",
-        }
-
-        self.create_mto_service_item(overrides)
-
-    @tag(PrimeObjects.MTO_SERVICE_ITEM.value, "createMTOServiceItemOriginSIT")
-    @task
-    def create_mto_service_item_origin_sit(self):
-        # This function ensures some origin SIT service items get requested.
-        # DOFSIT requests create the trio of origin SIT items that are needed for update_mto_service_item to function.
-        overrides = {
-            "reServiceCode": "DOFSIT",
-            "modelType": "MTOServiceItemOriginSIT",
-        }
-
-        self.create_mto_service_item(overrides)
-
     @tag(PrimeObjects.MTO_SHIPMENT.value, "createMTOShipment")
     @task
     def create_mto_shipment(self):
@@ -405,7 +381,6 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
                     "firstName": "Christopher",
                     "lastName": "Swinglehurst-Walters",
                     "agency": "MARINES",
-                    "rank": "E_6",
                     "email": "swinglehurst@example.com",
                     "rank": "E_3",
                     "dodID": "4586736251",
@@ -421,7 +396,6 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
                 "reportByDate": "2020-01-01",
                 "status": "SUBMITTED",
                 "issueDate": "2020-01-01",
-                "tac": "FB71",
             },
             "status": "SUBMITTED",
         }


### PR DESCRIPTION
## Description

Added a task for `updatePaymentRequestStatus` to load testing, checked that there were some successful runs. 

## Setup

Please run load testing with 
```sh
make load_test_prime
```

You need a lot of requests for there to be enough to create the specific types you want.

- run Locust with make load_test_prime
- In the locust load test, select 50/10 for number of "users to simulate" and for "swarm rate".
- Check to see how many failures there are.

Then watch the Locust statistics page and wait for at least a few hits on the /support/v1/payment-requests/{paymentRequestID}/status patch command.

### What to check for
Then check your logs and see if you can find some successful updatePaymentRequestStatus calls. 
```
tasks.base: ℹ️ updatePaymentRequestStatus status code: 200
tasks.base: ℹ️ updatePaymentRequestStatus successfully completed!
```



Since the logs are hard to read, here are some things to check for
- [ ] Did you catch some successful hits to the endpoint?
- [ ] Do the failures make sense?
- [ ] 500s are no good, if you catch them, add a ticket against milmove with the logs from the server.
Note, I ticketed one already. 500 error due to this reason has been ticketed.
`All PaymentServiceItems must be approved or denied to review this PaymentRequest`

## References

* [MB-3240 Support API: Load Testing - add task for updatePaymentRequestStatus](https://dp3.atlassian.net/browse/MB-3240)
