### PR TITLE
MB-6113 Load Testing: Fix endpoint task for updateMTOServiceItemStatus

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -380,8 +380,6 @@ class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
             # Moves that are in DRAFT or CANCELED mode cannot be used by the rest of the
             # loadtesting
             "status": "SUBMITTED",
-            # Must be set false, or triggers immediate cancelation of the MTO
-            "isCanceled": False,
             # If this date is set here, the status will not properly transition to APPROVED
             "availableToPrimeAt": None,
             "moveOrder": {


### PR DESCRIPTION
## Description

This PR is needed due to changes to the Support API endpoint updateMTOServiceItemStatus in: 
https://github.com/transcom/mymove/pull/5595

## Setup

- run Locust with make load_test_prime
- In the locust load test, select 50/10 for number of "users to simulate" and for "swarm rate".
- Check to see how many failures there are.

Then watch the Locust statistics page and wait for at least a few hits on the ` PATCH    /support/v1/mto-service-items/{mtoServiceItemID}/status` command. 

Then check your logs and see if you can find some successful updateMTOServiceItemStatus calls. Note there is a different endpoint called updateMTOServiceItem. 

Since the logs are hard to read, here are some things to check for
* [ ] Did you catch some successful hits to the endpoint?
* [ ] Do the failures make sense? 
* [ ] 500s are no good, if you catch them, add a ticket against milmove with the logs from the server. 

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

[MB-6113 Support API updateMTOServiceItemStatus returns a malformed service item](https://dp3.atlassian.net/browse/MB-6113)



