### PR TITLE
MB-2715 -Update-post-counseling-information

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -333,6 +333,30 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
         if success:
             self.replace_prime_data(PrimeObjects.MTO_SERVICE_ITEM, mto_service_item, resp)
 
+    @tag(PrimeObjects.POST_COUNSELING_INFORMATION.value, "updateMTOPostCounselingInformation")
+    def update_post_counseling_information(self):
+        move_task_order = self.get_random_data(PrimeObjects.MOVE_TASK_ORDER)
+        if not move_task_order:
+            logger.error(f"⛔️ No move_task_order \n{move_task_order}")
+            return  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
+
+        payload = self.fake_request("/move-task-orders/{moveTaskOrderID}/post-counseling-info", "patch")
+
+        move_task_order_id = move_task_order["id"]  # path parameter
+        headers = {"content-type": "application/json", "If-Match": move_task_order["eTag"]}
+
+        resp = self.client.patch(
+            support_path(f"/move-task-orders/{move_task_order_id}/post-counseling-info"),
+            name=support_path("/move-task-orders/{moveTaskOrderID}/post-counseling-info"),
+            data=json.dumps(payload),
+            headers=headers,
+            **self.user.cert_kwargs,
+        )
+        resp, success = check_response(resp, "updateMTOPostCounselingInformation", payload)
+
+        if success:
+            self.replace_prime_data(PrimeObjects.POST_COUNSELING_INFORMATION, move_task_order, resp)
+
 
 @tag("support")
 class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -333,7 +333,8 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
         if success:
             self.replace_prime_data(PrimeObjects.MTO_SERVICE_ITEM, mto_service_item, resp)
 
-    @tag(PrimeObjects.POST_COUNSELING_INFORMATION.value, "updateMTOPostCounselingInformation")
+    @tag(PrimeObjects.MOVE_TASK_ORDER.value, "updateMTOPostCounselingInformation")
+    @task
     def update_post_counseling_information(self):
         move_task_order = self.get_random_data(PrimeObjects.MOVE_TASK_ORDER)
         if not move_task_order:
@@ -346,8 +347,8 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
         headers = {"content-type": "application/json", "If-Match": move_task_order["eTag"]}
 
         resp = self.client.patch(
-            support_path(f"/move-task-orders/{move_task_order_id}/post-counseling-info"),
-            name=support_path("/move-task-orders/{moveTaskOrderID}/post-counseling-info"),
+            prime_path(f"/move-task-orders/{move_task_order_id}/post-counseling-info"),
+            name=prime_path("/move-task-orders/{moveTaskOrderID}/post-counseling-info"),
             data=json.dumps(payload),
             headers=headers,
             **self.user.cert_kwargs,
@@ -355,7 +356,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
         resp, success = check_response(resp, "updateMTOPostCounselingInformation", payload)
 
         if success:
-            self.replace_prime_data(PrimeObjects.POST_COUNSELING_INFORMATION, move_task_order, resp)
+            self.replace_prime_data(PrimeObjects.MOVE_TASK_ORDER, move_task_order, resp)
 
 
 @tag("support")

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -100,4 +100,3 @@ class PrimeObjects(ListEnum):
     MTO_SHIPMENT = "mtoShipment"
     MTO_SERVICE_ITEM = "mtoServiceItem"
     PAYMENT_REQUEST = "paymentRequest"
-    POST_COUNSELING_INFORMATION = "postCounselingInformation"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -100,3 +100,4 @@ class PrimeObjects(ListEnum):
     MTO_SHIPMENT = "mtoShipment"
     MTO_SERVICE_ITEM = "mtoServiceItem"
     PAYMENT_REQUEST = "paymentRequest"
+    POST_COUNSELING_INFORMATION = "postCounselingInformation"


### PR DESCRIPTION
## Description

Create new endpoint for updateMTOPostCounselingInformation

## Reviewer Notes

Please take a look at the overall code, and make sure the response was created correctly.

## Setup

To get locust running and see the new endpoint:

```python
make load_test_prime
```

In locust set the # of total users and the spawn rate to 5

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2715) for this change.
