### PR TITLE
MB-6656 Dynamically retrieve required move IDs to create MTOs in Experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,13 +300,12 @@ local environment:
 ```shell script
 make db_dev_e2e_populate  ## populates the development database with test data
 make server_run
-make client_run
 ```
 
 Back in `milmove_load_testing`, make sure you activate your virtual environment before attempting to run tests:
 
 ```shell script
-pyenv activate locust-env
+pyenv activate locust-venv
 ```
 
 ### Running preset tests

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,5 +9,5 @@ services:
      - DEVLOCAL_AUTH=true
      - MOVE_MIL_EXP_TLS_CERT
      - MOVE_MIL_EXP_TLS_KEY
-    command: -f /app/locustfiles/prime.py --host exp --tags fetchMTOUpdates
-    # TODO Fix create_move_task_order in experimental so we can remove the --tags flag
+    command: -f /app/locustfiles/prime.py --host exp
+    # TODO Write command for a regular timed load test in experimental

--- a/locustfiles/prime.py
+++ b/locustfiles/prime.py
@@ -27,7 +27,6 @@ class PrimeUser(MilMoveHostMixin, HttpUser):
     # These are locust HttpUser attributes that help define and shape the load test:
     wait_time = between(0.25, 9)  # the time period to wait in between tasks (in seconds, accepts decimals and 0)
     tasks = {PrimeTasks: 1}  # the set of tasks to be executed and their relative weight
-    weight = 5
 
 
 class SupportUser(MilMoveHostMixin, HttpUser):
@@ -43,7 +42,6 @@ class SupportUser(MilMoveHostMixin, HttpUser):
 
     wait_time = between(0.25, 9)
     tasks = {SupportTasks: 1}
-    weight = 1
 
 
 @events.test_stop.add_listener

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black>=19.3b0
 flake8
 pytest
 pytest-mock
+responses

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -55,6 +55,7 @@ class CertTaskMixin:
     `self.client.get('url', **self.user.cert_kwargs)`
 
     NOTE: MUST BE PLACED BEFORE TaskSet IN MRO INHERITANCE
+    because TaskSet.__init__ does not call super(), which means this logic will not execute if TaskSet resolves first.
     """
 
     def __init__(self, parent):
@@ -63,6 +64,14 @@ class CertTaskMixin:
         # Check that the User class calling these tasks implements cert_kwargs:
         if not hasattr(self.user, "cert_kwargs"):
             setattr(self.user, "cert_kwargs", {})  # set an empty dict to avoid attribute errors later on
+
+    @property
+    def cert_kwargs(self):
+        """
+        Shortcut to the cert_kwargs attribute of this TaskSet's locust.users.User class or subclass of
+        milmove_load_testing.utils.hosts.MilMoveHostMixin.
+        """
+        return self.user.cert_kwargs
 
 
 class ParserTaskMixin:

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -7,7 +7,6 @@ from locust import TaskSet
 import logging
 from requests import Response
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -52,10 +51,10 @@ class CertTaskMixin:
     TaskSet mixin class that uses a cert_kwargs dictionary set in the User class calling the tasks. Set up for local
     mTLS in particular. Client calls in this TaskSet should look like:
 
-    `self.client.get('url', **self.user.cert_kwargs)`
+    `self.client.get('url', **self.cert_kwargs)`
 
     NOTE: MUST BE PLACED BEFORE TaskSet IN MRO INHERITANCE
-    because TaskSet.__init__ does not call super(), which means this logic will not execute if TaskSet resolves first.
+    because TaskSet.__init__ does not call super(), meaning this logic will not execute if TaskSet resolves first.
     """
 
     def __init__(self, parent):
@@ -80,6 +79,7 @@ class ParserTaskMixin:
     defined.
 
     NOTE: MUST BE PLACED BEFORE TaskSet IN MRO INHERITANCE
+    because TaskSet.__init__ does not call super(), meaning this logic will not execute if TaskSet resolves first.
     """
 
     def __init__(self, parent):

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -42,7 +42,12 @@ class PrimeDataStorageMixin:
 
     DATA_LIST_MAX: int = 50
     # contains the ID values needed when creating moves using createMoveTaskOrder:
-    default_mto_ids: Dict[str, str] = {}
+    default_mto_ids: Dict[str, str] = {
+        "contractorID": "",
+        "destinationDutyStationID": "",
+        "originDutyStationID": "",
+        "uploadedOrdersID": "",
+    }
     local_store: Dict[str, list] = {
         MOVE_TASK_ORDER: [],
         MTO_SHIPMENT: [],
@@ -150,8 +155,9 @@ class PrimeDataStorageMixin:
         :param moves: list of JSON/dict objects
         :return: None
         """
-        if all(self.default_mto_ids.values()):
-            return  # if we already have all of the ID values, we don't need to run through this logic again
+        # Checks that we have a full set of MTO IDs already and halts processing if so:
+        if self.default_mto_ids and all(self.default_mto_ids.values()):
+            return
 
         headers = {"content-type": "application/json"}
         for move in moves:

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -117,10 +117,12 @@ class PrimeDataStorageMixin:
         """
         data_list = self.local_store[object_key]
 
-        try:
-            data_list.remove(old_data)
-        except ValueError:
-            pass  # this is fine, we didn't want this value in the list anymore anyway
+        # Remove all instances of the stored object, in case multiples were added erroneously:
+        while True:
+            try:
+                data_list.remove(old_data)
+            except ValueError:
+                break  # this means we finally cleared the list
 
         data_list.append(new_data)
 

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -71,7 +71,7 @@ class PrimeDataStorageMixin:
         :return: tuple(str name of the address field, dict address payload)
         """
         if not mto_shipment:
-            mto_shipment = self.get_stored(MTO_SHIPMENT)
+            mto_shipment = self.get_stored(MTO_SHIPMENT) or {}
 
         address_fields = ["pickupAddress", "destinationAddress"]
         valid_addresses = [

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -31,7 +31,7 @@ def support_path(url):
     return f"/support/v1{url}"
 
 
-class PrimeDataTaskMixin:
+class PrimeDataStorageMixin:
     """
     TaskSet mixin used to store data from the Prime API during load testing so that it can be passed around and reused.
     We store a number of objects in a local store that can be requested by tasks.
@@ -187,7 +187,7 @@ class PrimeDataTaskMixin:
 
 
 @tag("prime")
-class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
+class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     """
     Set of the tasks that can be called on the Prime API. Make sure to mark tasks with the `@task` decorator and add
     tags where appropriate to make filtering for custom tests easier.
@@ -455,7 +455,7 @@ class PrimeTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
 
 
 @tag("support")
-class SupportTasks(PrimeDataTaskMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
+class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet):
     """
     Set of the tasks that can be called on the Support API. Make sure to mark tasks with the `@task` decorator and add
     tags where appropriate to make filtering for custom tests easier. Ex:

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -146,12 +146,6 @@ class PrimeDataStorageMixin:
 
         CAN ONLY be used when subclassed with TaskSet and CertTaskMixin.
 
-        Local values we used to default to (before we needed to make this process dynamic for deployed envs):
-          "contractorID": "5db13bb4-6d29-4bdb-bc81-262f4513ecf6",
-          "destinationDutyStationID": "71b2cafd-7396-4265-8225-ff82be863e01",
-          "originDutyStationID": "1347d7f3-2f9a-44df-b3a5-63941dd55b34",
-          "uploadedOrdersID": "c26421b0-e4c3-446b-88f3-493bb25c1756",
-
         :param moves: list of JSON/dict objects
         :return: None
         """
@@ -195,6 +189,19 @@ class PrimeDataStorageMixin:
             if all(self.default_mto_ids.values()):
                 logger.info(f"☑️ Set default MTO IDs for createMoveTaskOrder: \n{self.default_mto_ids}")
                 break
+
+        # If we're in the local environment, and we have gone through the entire list without getting a full set of IDs,
+        # set our hardcoded IDs as the default:
+        if not all(self.default_mto_ids.values()) and self.user.is_local:
+            logger.warning("⚠️ Using hardcoded MTO IDs for LOCAL env")
+            self.default_mto_ids.update(
+                {
+                    "contractorID": "5db13bb4-6d29-4bdb-bc81-262f4513ecf6",
+                    "destinationDutyStationID": "71b2cafd-7396-4265-8225-ff82be863e01",
+                    "originDutyStationID": "1347d7f3-2f9a-44df-b3a5-63941dd55b34",
+                    "uploadedOrdersID": "c26421b0-e4c3-446b-88f3-493bb25c1756",
+                }
+            )
 
 
 @tag("prime")

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -23,11 +23,11 @@ from .base import check_response, CertTaskMixin, ParserTaskMixin
 logger = logging.getLogger(__name__)
 
 
-def prime_path(url):
+def prime_path(url: str) -> str:
     return f"/prime/v1{url}"
 
 
-def support_path(url):
+def support_path(url: str) -> str:
     return f"/support/v1{url}"
 
 

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -4,6 +4,7 @@ import logging
 import json
 import random
 from copy import deepcopy
+from typing import Dict
 
 from locust import tag, task, TaskSet
 
@@ -39,10 +40,10 @@ class PrimeDataStorageMixin:
     This mixin allows storing multiple items of each kind.
     """
 
-    DATA_LIST_MAX = 50
+    DATA_LIST_MAX: int = 50
     # contains the ID values needed when creating moves using createMoveTaskOrder:
-    default_mto_ids = {}
-    local_store = {
+    default_mto_ids: Dict[str, str] = {}
+    local_store: Dict[str, list] = {
         MOVE_TASK_ORDER: [],
         MTO_SHIPMENT: [],
         MTO_SERVICE_ITEM: [],
@@ -136,6 +137,8 @@ class PrimeDataStorageMixin:
         Support API instead. It will go through and hit this endpoint for all of the moves in the list until it finally
         gets a complete set of IDs.
 
+        CAN ONLY be used when subclassed with TaskSet and CertTaskMixin.
+
         Local values we used to default to (before we needed to make this process dynamic for deployed envs):
           "contractorID": "5db13bb4-6d29-4bdb-bc81-262f4513ecf6",
           "destinationDutyStationID": "71b2cafd-7396-4265-8225-ff82be863e01",
@@ -155,7 +158,7 @@ class PrimeDataStorageMixin:
                 support_path(f"/move-task-orders/{move['id']}"),
                 name=support_path("/move-task-orders/{moveTaskOrderID}"),
                 headers=headers,
-                **self.user.cert_kwargs,
+                **self.cert_kwargs,
             )
             move_details, success = check_response(resp, "getMoveTaskOrder")
 

--- a/tasks/tests/test_prime.py
+++ b/tasks/tests/test_prime.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+""" Tests tasks/prime.py """
+import pytest
+
+from requests import Session
+
+from tasks.prime import PrimeDataStorageMixin
+from utils.constants import MOVE_TASK_ORDER, MTO_SHIPMENT, MTO_SERVICE_ITEM, PAYMENT_REQUEST, ZERO_UUID
+
+
+class TestPrimeDataStorageMixin:
+    """
+    Tests the PrimeDataStorageMixin class and its methods. This class is intended to be subclasses and work on ALL
+    instances of inheriting classes.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        """ Define and initialize the classes that will be tested. """
+        # environment = Environment(events=Events(), catch_exceptions=False)
+
+        class MockSession(Session):
+            def get(self, name, **kwargs):
+                return super().get(**kwargs)
+
+        class PrimeStorage1(PrimeDataStorageMixin):
+            DATA_LIST_MAX = 3
+            client = MockSession()
+
+        class PrimeStorage2(PrimeDataStorageMixin):
+            DATA_LIST_MAX = 3
+            client = MockSession()
+
+        cls.storage1 = PrimeStorage1()
+        cls.storage2 = PrimeStorage2()
+
+    @pytest.mark.parametrize(
+        "object_key,test_store",
+        [
+            (MOVE_TASK_ORDER, ["MTO 1"]),
+            (MTO_SERVICE_ITEM, ["item 1", "item 2", "item 3"]),
+        ],
+    )
+    def test_get_stored(self, object_key, test_store):
+        """ Test retrieving a random object from the local_store dictionary lists. """
+        self.storage1.local_store[object_key] = test_store
+
+        assert self.storage1.get_stored(object_key) in test_store
+        assert self.storage2.get_stored(object_key) in test_store
+        assert len(self.storage1.local_store[object_key]) == len(self.storage2.local_store[object_key])
+
+    def test_get_stored__empty(self):
+        """ Test the get_stored() method with an empty list of data. """
+        empty_list = "empty"
+        self.storage1.local_store[empty_list] = []
+
+        assert self.storage1.get_stored(empty_list) is None
+        assert self.storage2.get_stored(empty_list) is None
+
+    @pytest.mark.parametrize(
+        "shipment_test_store",
+        [
+            ([{"pickupAddress": {"no": "id"}, "destinationAddress": {"id": "01010"}}]),
+            ([{"destinationAddress": {"id": "1234"}}, {"pickupAddress": {"id": "5555555"}}]),
+        ],
+    )
+    def test_get_stored_shipment_address(self, shipment_test_store):
+        """ Test the process of getting a random address from the MTO_SHIPMENT local store. """
+        self.storage1.local_store[MTO_SHIPMENT] = shipment_test_store
+        field, address = self.storage1.get_stored_shipment_address()
+
+        assert any([shipment.get(field) == address for shipment in self.storage1.local_store[MTO_SHIPMENT]])
+        assert any([shipment.get(field) == address for shipment in self.storage2.local_store[MTO_SHIPMENT]])
+        assert address["id"] != ZERO_UUID
+
+    @pytest.mark.parametrize(
+        "test_shipment",
+        [
+            (
+                {
+                    "pickupAddress": {"id": "1234"},
+                    "destinationAddress": {"id": "5768"},
+                }
+            ),
+            (
+                {
+                    "pickupAddress": {"id": "11111"},
+                    "destinationAddress": {"id": ZERO_UUID},
+                }
+            ),
+            (
+                {
+                    "destinationAddress": {"id": "1357"},
+                }
+            ),
+        ],
+    )
+    def test_get_stored_shipment_address__given_shipment(self, test_shipment):
+        """ Test the process of getting a random address from an MTO_SHIPMENT object passed in as an argument. """
+        test_shipment = {"pickupAddress": {"id": "1234"}, "destinationAddress": {"id": "5768"}}
+        field, address = self.storage1.get_stored_shipment_address(test_shipment)
+
+        assert test_shipment[field] == address
+        assert address["id"] != ZERO_UUID
+
+    @pytest.mark.parametrize(
+        "test_store",
+        [
+            ([]),
+            ([{"no": "address"}]),
+            ([{"pickupAddress": {"no": "id"}}]),
+            ([{"destinationAddress": {"id": ZERO_UUID}}]),
+        ],
+    )
+    def test_get_stored_shipment_address__none_found(self, test_store):
+        """ Test get_stored_shipment_address when there are no valid addresses. """
+        self.storage1.local_store[MTO_SHIPMENT] = test_store
+        with pytest.raises(TypeError):
+            _field, _address = self.storage1.get_stored_shipment_address()
+
+        assert self.storage1.get_stored_shipment_address() is None
+        assert self.storage2.get_stored_shipment_address() is None
+
+    @pytest.mark.parametrize(
+        "object_key,new_object,test_store",
+        [
+            (MOVE_TASK_ORDER, "new MTO", []),
+            (PAYMENT_REQUEST, "new payment", ["old payment"]),
+            (MTO_SERVICE_ITEM, "over data list max", ["item 1", "item 2", "item 3"]),
+        ],
+    )
+    def test_add_stored(self, object_key, new_object, test_store):
+        """ Test adding an object to local storage. """
+        self.storage1.local_store[object_key] = test_store
+        self.storage1.add_stored(object_key, new_object)
+
+        assert new_object in self.storage1.local_store[object_key]
+        assert new_object in self.storage2.local_store[object_key]
+        assert len(self.storage1.local_store[object_key]) == len(self.storage2.local_store[object_key])
+
+    def test_add_stored__list(self):
+        """ Test adding a list of objects to local storage. """
+        new_data = ["multiple", "new", "objects"]
+        self.storage1.local_store[PAYMENT_REQUEST] = ["payment"]
+        self.storage1.add_stored(PAYMENT_REQUEST, new_data)
+
+        assert all([data in self.storage1.local_store[PAYMENT_REQUEST] for data in new_data])
+        assert all([data in self.storage2.local_store[PAYMENT_REQUEST] for data in new_data])
+        assert len(self.storage1.local_store[PAYMENT_REQUEST]) == 4
+        assert len(self.storage2.local_store[PAYMENT_REQUEST]) == 4
+
+    @pytest.mark.parametrize(
+        "object_key,old_object,new_object,test_store",
+        [
+            (MOVE_TASK_ORDER, "old MTO", "new MTO", ["old MTO"]),
+            (PAYMENT_REQUEST, "old payment", "new payment", []),  # "new payment" should be added w/o error
+            (MTO_SERVICE_ITEM, "item 3", "the third item", ["item 1", "item 2", "item 3"]),
+            # both "item 3"s should be removed:
+            (MTO_SERVICE_ITEM, "item 3", "the third item", ["item 1", "item 2", "item 3", "item 3"]),
+        ],
+    )
+    def test_update_stored(self, object_key, old_object, new_object, test_store):
+        """ Test updating an object that is already in the local storage. """
+        self.storage1.local_store[object_key] = test_store
+        self.storage1.update_stored(object_key, old_object, new_object)
+
+        assert new_object in self.storage1.local_store[object_key]
+        assert new_object in self.storage2.local_store[object_key]
+        assert old_object not in self.storage1.local_store[object_key]
+        assert old_object not in self.storage2.local_store[object_key]
+        assert len(self.storage1.local_store[object_key]) == len(self.storage2.local_store[object_key])
+
+    # def test_set_default_mto_ids(self):
+    #     """TODO MOCKS"""

--- a/tasks/tests/test_prime_workflow.py
+++ b/tasks/tests/test_prime_workflow.py
@@ -211,7 +211,7 @@ class TestPrimeWorkflowTasks(LocustTestCase):
         assert shipment["id"] == "56789" or shipment["id"] == "34567"
 
         # Get a specific shipment
-        shipment = self.taskset.get_stored(MTO_SHIPMENT, id="34567")
+        shipment = self.taskset.get_stored(MTO_SHIPMENT, object_id="34567")
         assert shipment["id"] == "34567"
 
         # Scenario: We add a move and no shipments
@@ -227,5 +227,5 @@ class TestPrimeWorkflowTasks(LocustTestCase):
         shipment = self.taskset.get_stored(MTO_SHIPMENT)
         assert shipment is None
 
-        shipment = self.taskset.get_stored(MTO_SHIPMENT, id="34567")
+        shipment = self.taskset.get_stored(MTO_SHIPMENT, object_id="34567")
         assert shipment is None

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -164,7 +164,7 @@ class MilMoveHostMixin:
         cls.cert_kwargs = {"cert": cert_key, "verify": DOD_CA_BUNDLE}
 
     @classmethod
-    def create_deployed_cert_file(cls) -> str:
+    def create_deployed_cert_file(cls) -> Optional[str]:
         """
         Grabs the TLS certificate and key values for this environment from the relevant environment variables (which
         must be set for this function to work), and then creates a new .pem file that contains both the certificate and

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -220,6 +220,16 @@ class MilMoveHostMixin:
         # Finally, clear out all traces of the deployed cert file:
         cls.cert_kwargs = {}
 
+    @property
+    def is_local(self):
+        """ Indicates if this user is using the local environment. """
+        return self.env == MilMoveEnv.LOCAL
+
+    @property
+    def is_deployed(self):
+        """ Indicates if this user is running in a deployed environment. """
+        return self.env != MilMoveEnv.LOCAL
+
 
 def clean_milmove_host_users(locust_env: Environment):
     """

--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -447,7 +447,8 @@ class SupportAPIParser(PrimeAPIParser):
 
             move_task_order.pop("moveOrderID", None)  # moveOrderID will be returned on creation
 
-            # Cannot create certain nested objects with this endpoint, instead the caller should pass in an ID (in overrides)
+            # Cannot create certain nested objects with this endpoint, instead the caller should pass in an ID
+            # (in overrides)
             move_orders.pop("uploadedOrders", None)
             move_orders.pop("originDutyStation", None)
             move_orders.pop("destinationDutyStation", None)


### PR DESCRIPTION
## Description

This PR removes the hardcoded IDs for:
 - `contractorID`
 - `uploadedOrdersID`
 - `destinationDutyStationID`
 - `originDutyStationID`

All of these values are required for the Support API endpoint `createMoveTaskOrder`, which is the pivotal request in our load testing process because it gives us MTOs to work with. In order to run these tests in experimental, we must grab these values from MTOs that already exist in the experimental database. We use the Support API `getMoveTaskOrder` endpoint to do this with the moves we get back from the Prime API's `fetchMTOUpdates`.

## Setup

To test this update, you must work with the `mymove` updates in this PR: https://github.com/transcom/mymove/pull/5861. For a local test, checkout and run the server off the branch `sw-upd-create-mto-for-load-testing`. For a test in experimental, you will either need to wait until this PR is merged with master, or claim and deploy this branch to experimental yourself. 

### Local Testing

Start up your local server:
```sh
make db_dev_e2e_populate server_run
```

And run the load tests:
```sh
make load_test_prime
```

or:
```sh
make load_test_prime_workflow
```

If you see successful calls to the `createMoveTaskOrder` endpoint (`POST | /support/v1/move-task-orders`), then the code works! You can peek in the logs and look for a line like `☑️ Set default MTO IDs for createMoveTaskOrder:` to see which IDs were set.

### Testing in Experimental

Build and run the docker container:
```sh
docker-compose build
docker-compose up
```

Navigate to http://localhost:8089/ to use the web UI to run the test. Spawn 2 users and view the results closely. Once the `createMoveTaskOrder` endpoint has been hit a couple of times, **stop the load test. DO NOT let the test run unmonitored in experimental. We DO NOT want to flood this environment with new moves (yet).**

You should see some successfully created moves. Yay!

### Running Unit Tests

To run the unit tests for the new code, you will first need to install the new required package (in your pyenv virtual environment):
```sh
pyenv activate locust-venv
pip install -r requirements-dev.txt
```

Then use `pytest` to run the tests:
```sh
pytest tasks/tests/test_prime.py
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6656) for this change.
