### PR TITLE
[MB-6219] Add shipments and serviceitems to the prime workflow in load testing

### DIFF
--- a/tasks/base.py
+++ b/tasks/base.py
@@ -21,7 +21,7 @@ def check_response(response: Response, task_name="Task", request=None):
     :param request: any type, optional data to print for debugging a failed response
     :return: tuple(dict, bool)
     """
-    logger.info(f"ℹ️ {task_name} status code: {response.status_code}")
+    logger.info(f"ℹ️ {task_name} status code: {response.status_code} {response.reason}")
 
     try:
         json_response = json.loads(response.content)
@@ -40,8 +40,6 @@ def check_response(response: Response, task_name="Task", request=None):
                 logger.error(f"Request data:\n{response.request.method} {response.request.url}\n{request}")
 
         return json_response, False
-
-    logger.info(f"ℹ️ {task_name} successfully completed!")
 
     return json_response, True
 

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -225,47 +225,65 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         if success:
             self.set_default_mto_ids(moves)
 
+        return None
+
     @tag(MTO_SERVICE_ITEM, "createMTOServiceItem")
     @task
     def create_mto_service_item(self, overrides=None):
-        mto_shipment = self.get_stored(MTO_SHIPMENT)
+        # If mtoShipmentID was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("mtoShipmentID") if overrides else None
+        mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
         if not mto_shipment:
-            return
+            logger.error("⛔️ No mto shipment\n")
+            return None
 
         overrides_local = {
+            # override moveTaskOrderID because we don't want a random one
             "moveTaskOrderID": mto_shipment["moveTaskOrderID"],
+            # override mtoShipmentID because we don't want a random one
             "mtoShipmentID": mto_shipment["id"],
         }
         # Merge local overrides with passed-in overrides
-        if overrides:
-            overrides_local.update(overrides)
-        payload = self.fake_request("/mto-service-items", "post", PRIME_API_KEY, overrides=overrides_local)
+        overrides_local.update(overrides or {})
+        payload = self.fake_request("/mto-service-items", "post", PRIME_API_KEY, overrides_local)
 
         headers = {"content-type": "application/json"}
         resp = self.client.post(
             prime_path("/mto-service-items"), data=json.dumps(payload), headers=headers, **self.user.cert_kwargs
         )
 
-        resp, success = check_response(resp, f"createMTOServiceItem {payload['reServiceCode']}", payload)
+        mto_service_items, success = check_response(resp, f"createMTOServiceItem {payload['reServiceCode']}", payload)
 
         if success:
-            self.add_stored(MTO_SERVICE_ITEM, resp)
+            self.add_stored(MTO_SERVICE_ITEM, mto_service_items)
+            return mto_service_items
+
+        return None
 
     @tag(MTO_SHIPMENT, "createMTOShipment")
     @task
     def create_mto_shipment(self, overrides=None):
-        move_task_order = self.get_stored(MOVE_TASK_ORDER)
+        # If moveTaskOrderID was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("moveTaskOrderID") if overrides else None
+        mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
+
+        move_task_order = self.get_stored(MOVE_TASK_ORDER, object_id)
         if not move_task_order:
             return (
                 None  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
             )
 
         overrides_local = {
+            # Override moveTaskorderID because we don't want a random one
             "moveTaskOrderID": move_task_order["id"],
+            # Set agents UUIDs to ZERO_UUID because we can't actually set the UUID on creation
             "agents": {"id": ZERO_UUID, "mtoShipmentID": ZERO_UUID},
+            # Set pickupAddress to ZERO_UUID because we can't actually set the UUID on creation
             "pickupAddress": {"id": ZERO_UUID},
+            # Set destinationAddress to ZERO_UUID because we can't actually set the UUID on creation
             "destinationAddress": {"id": ZERO_UUID},
-            "mtoServiceItems": [],  # let the create_mto_service_item endpoint handle creating these
+            # Set mtoServiceItems to empty to let the createMTOServiceItems endpoint do the creation
+            "mtoServiceItems": [],
         }
         # Merge local overrides with passed-in overrides
         if overrides:
@@ -286,8 +304,10 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
 
     @tag(PAYMENT_REQUEST, "createUpload")
     @task
-    def create_upload(self):
-        payment_request = self.get_stored(PAYMENT_REQUEST)
+    def create_upload(self, overrides=None):
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        payment_request = self.get_stored(PAYMENT_REQUEST, object_id)
         if not payment_request:
             return
 
@@ -303,8 +323,10 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
 
     @tag(PAYMENT_REQUEST, "createPaymentRequest")
     @task
-    def create_payment_request(self):
-        service_item = self.get_stored(MTO_SERVICE_ITEM)
+    def create_payment_request(self, overrides):
+        # If mtoServiceItemID was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("mtoServiceItemID") if overrides else None
+        service_item = self.get_stored(MTO_SERVICE_ITEM, object_id)
         if not service_item:
             return
 
@@ -318,19 +340,24 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         resp = self.client.post(
             prime_path("/payment-requests"), data=json.dumps(payload), headers=headers, **self.user.cert_kwargs
         )
-        resp, success = check_response(resp, "createPaymentRequest", payload)
+        payment_request, success = check_response(resp, "createPaymentRequest", payload)
 
         if success:
-            self.add_stored(PAYMENT_REQUEST, resp)
+            self.add_stored(PAYMENT_REQUEST, payment_request)
+            return payment_request
+
+        return None
 
     @tag(MTO_SHIPMENT, "updateMTOShipment")
     @task
-    def update_mto_shipment(self):
-        mto_shipment = self.get_stored(MTO_SHIPMENT)
+    def update_mto_shipment(self, overrides=None):
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
         if not mto_shipment:
             return  # can't run this task
 
-        payload = self.fake_request("/mto-shipments/{mtoShipmentID}", "put", PRIME_API_KEY)
+        payload = self.fake_request("/mto-shipments/{mtoShipmentID}", "put", PRIME_API_KEY, overrides)
 
         # Agents and addresses should not be updated by this endpoint, and primeEstimatedWeight cannot be updated after
         # it is initially set (and it is set in create_mto_shipment)
@@ -353,15 +380,20 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             headers=headers,
             **self.user.cert_kwargs,
         )
-        resp, success = check_response(resp, "updateMTOShipment", payload)
+        new_mto_shipment, success = check_response(resp, "updateMTOShipment", payload)
 
         if success:
-            self.update_stored(MTO_SHIPMENT, mto_shipment, resp)
+            self.update_stored(MTO_SHIPMENT, mto_shipment, new_mto_shipment)
+            return new_mto_shipment
+
+        return None
 
     @tag(MTO_SHIPMENT, "updateMTOShipmentAddress")
     @task
-    def update_mto_shipment_address(self):
-        mto_shipment = self.get_stored(MTO_SHIPMENT)
+    def update_mto_shipment_address(self, overrides):
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
         if not mto_shipment:
             return
 
@@ -371,9 +403,10 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
 
         field, address = address_tuple
 
-        overrides = {"id": address["id"]}
+        overrides_local = {"id": address["id"]}
+        overrides_local.update(overrides or {})
         payload = self.fake_request(
-            "/mto-shipments/{mtoShipmentID}/addresses/{addressID}", "put", PRIME_API_KEY, overrides=overrides
+            "/mto-shipments/{mtoShipmentID}/addresses/{addressID}", "put", PRIME_API_KEY, overrides=overrides_local
         )
 
         headers = {"content-type": "application/json", "If-Match": address["eTag"]}
@@ -385,19 +418,24 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             headers=headers,
             **self.user.cert_kwargs,
         )
-        resp, success = check_response(resp, "updateMTOShipmentAddress", payload)
+        updated_address, success = check_response(resp, "updateMTOShipmentAddress", payload)
 
         if success:
+            # we only got the address, so we're gonna pop it back into the shipment to store
             updated_shipment = deepcopy(mto_shipment)
-            updated_shipment[field] = resp
+            updated_shipment[field] = updated_address
             self.update_stored(MTO_SHIPMENT, mto_shipment, updated_shipment)
+            return updated_shipment
+
+        return None
 
     @tag(MTO_AGENT, "updateMTOAgent")
     @task
-    def update_mto_agent(self):
-        mto_shipment = self.get_stored(
-            MTO_SHIPMENT
-        )  # this grabs response payload from the MTO_AGENT list when load testing runs
+    def update_mto_agent(self, overrides):
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("mtoShipmentID") if overrides else None
+        mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
+
         if not mto_shipment:
             return  # can't run this task
         if mto_shipment.get("agents") is None:
@@ -414,17 +452,23 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             **self.user.cert_kwargs,
         )
 
-        resp, success = check_response(resp, "updateMTOAgent", payload)
+        updated_agent, success = check_response(resp, "updateMTOAgent", payload)
 
         if success:
+            # we only got the agent, so we're gonna pop it back into the shipment to store
             new_shipment = deepcopy(mto_shipment)
-            new_shipment["agents"][0] = resp
+            new_shipment["agents"][0] = updated_agent
             self.update_stored(MTO_SHIPMENT, mto_shipment, new_shipment)
+            return new_shipment
+
+        return None
 
     @tag(MTO_SERVICE_ITEM, "updateMTOServiceItem")
     @task
-    def update_mto_service_item(self):
-        mto_service_item = self.get_stored(MTO_SERVICE_ITEM)
+    def update_mto_service_item(self, overrides=None):
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        mto_service_item = self.get_stored(MTO_SERVICE_ITEM, object_id)
         if not mto_service_item:
             return  # can't run this task
 
@@ -440,7 +484,6 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
                 "[DDDSIT, DOPSIT]"
             )
             return
-
         payload = self.fake_request(
             "/mto-service-items/{mtoServiceItemID}", "patch", overrides={"id": mto_service_item["id"]}
         )
@@ -453,15 +496,20 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             headers=headers,
             **self.user.cert_kwargs,
         )
-        resp, success = check_response(resp, f"updateMTOServiceItem {re_service_code}", payload)
+        updated_service_item, success = check_response(resp, f"updateMTOServiceItem {re_service_code}", payload)
 
         if success:
-            self.update_stored(MTO_SERVICE_ITEM, mto_service_item, resp)
+            self.update_stored(MTO_SERVICE_ITEM, mto_service_item, updated_service_item)
+            return updated_service_item
+
+        return None
 
     @tag(MOVE_TASK_ORDER, "updateMTOPostCounselingInformation")
     @task
-    def update_post_counseling_information(self):
-        move_task_order = self.get_stored(MOVE_TASK_ORDER)
+    def update_post_counseling_information(self, overrides=None):
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        move_task_order = self.get_stored(MOVE_TASK_ORDER, object_id)
         if not move_task_order:
             logger.error(f"⛔️ No move_task_order \n{move_task_order}")
             return  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
@@ -482,6 +530,9 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
 
         if success:
             self.update_stored(MOVE_TASK_ORDER, move_task_order, new_mto)
+            return new_mto
+
+        return None
 
 
 @tag("support")
@@ -499,8 +550,9 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
     @tag(MTO_SHIPMENT, "updateMTOShipmentStatus")
     @task
     def update_mto_shipment_status(self, overrides=None):
-        # Get shipment we've previously stored in PrimeObjects
-        mto_shipment = self.get_stored(MTO_SHIPMENT)
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
         if not mto_shipment:
             return None  # can't run this task
 
@@ -574,16 +626,21 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
 
         if success:
             self.add_stored(MOVE_TASK_ORDER, new_mto)
+            return new_mto
+
+        return None
 
     @tag(MTO_SERVICE_ITEM, "updateMTOServiceItemStatus")
     @task
-    def update_mto_service_item_status(self):
-        mto_service_item = self.get_stored(MTO_SERVICE_ITEM)
+    def update_mto_service_item_status(self, overrides):
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        mto_service_item = self.get_stored(MTO_SERVICE_ITEM, object_id)
         # if we don't have an mto shipment we can't run this task
         if not mto_service_item:
-            return
+            return None
 
-        payload = self.fake_request("/mto-service-items/{mtoServiceItemID}/status", "patch", SUPPORT_API_KEY)
+        payload = self.fake_request("/mto-service-items/{mtoServiceItemID}/status", "patch", SUPPORT_API_KEY, overrides)
         headers = {"content-type": "application/json", "If-Match": mto_service_item["eTag"]}
 
         resp = self.client.patch(
@@ -594,15 +651,18 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
             **self.user.cert_kwargs,
         )
 
-        mto_service_item_data, success = check_response(resp, "updateMTOServiceItemStatus", payload)
+        mto_service_item, success = check_response(resp, "updateMTOServiceItemStatus", payload)
 
         if success:
-            self.update_stored(MTO_SERVICE_ITEM, mto_service_item, mto_service_item_data)
+            self.update_stored(MTO_SERVICE_ITEM, mto_service_item, mto_service_item)
+            return mto_service_item
+
+        return None
 
     @tag(PAYMENT_REQUEST, "updatePaymentRequestStatus")
     @task
-    def update_payment_request_status(self):
-        payment_request = self.get_stored(PAYMENT_REQUEST)
+    def update_payment_request_status(self, overrides=None):
+        payment_request = self.get_stored(PAYMENT_REQUEST, object_id=overrides.get("id"))
         if not payment_request:
             return
 
@@ -620,11 +680,16 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
 
         if success:
             self.update_stored(PAYMENT_REQUEST, payment_request, new_payment_request)
+            return new_payment_request
+
+        return None
 
     @tag(MOVE_TASK_ORDER, "getMoveTaskOrder")
     @task
-    def get_move_task_order(self):
-        move_task_order = self.get_stored(MOVE_TASK_ORDER)
+    def get_move_task_order(self, overrides=None):
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        move_task_order = self.get_stored(MOVE_TASK_ORDER, object_id)
         if not move_task_order:
             logger.error(f"⛔️ No move_task_order \n{move_task_order}")
             return
@@ -641,3 +706,6 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
 
         if success:
             self.update_stored(MOVE_TASK_ORDER, move_task_order, new_mto)
+            return new_mto
+
+        return None

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -236,7 +236,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             "moveTaskOrderID": mto_shipment["moveTaskOrderID"],
             "mtoShipmentID": mto_shipment["id"],
         }
-        # override local overrides with parameter overrides
+        # Merge local overrides with passed-in overrides
         if overrides:
             overrides_local.update(overrides)
         payload = self.fake_request("/mto-service-items", "post", PRIME_API_KEY, overrides=overrides_local)
@@ -253,28 +253,36 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
 
     @tag(MTO_SHIPMENT, "createMTOShipment")
     @task
-    def create_mto_shipment(self):
+    def create_mto_shipment(self, overrides=None):
         move_task_order = self.get_stored(MOVE_TASK_ORDER)
         if not move_task_order:
-            return  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
+            return (
+                None  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
+            )
 
-        overrides = {
+        overrides_local = {
             "moveTaskOrderID": move_task_order["id"],
             "agents": {"id": ZERO_UUID, "mtoShipmentID": ZERO_UUID},
             "pickupAddress": {"id": ZERO_UUID},
             "destinationAddress": {"id": ZERO_UUID},
             "mtoServiceItems": [],  # let the create_mto_service_item endpoint handle creating these
         }
-        payload = self.fake_request("/mto-shipments", "post", PRIME_API_KEY, overrides=overrides)
+        # Merge local overrides with passed-in overrides
+        if overrides:
+            overrides_local.update(overrides)
+        payload = self.fake_request("/mto-shipments", "post", PRIME_API_KEY, overrides=overrides_local)
 
         headers = {"content-type": "application/json"}
         resp = self.client.post(
             prime_path("/mto-shipments"), data=json.dumps(payload), headers=headers, **self.user.cert_kwargs
         )
-        resp, success = check_response(resp, "createMTOShipment", payload)
+        mto_shipment, success = check_response(resp, "createMTOShipment", payload)
 
         if success:
-            self.add_stored(MTO_SHIPMENT, resp)
+            self.add_stored(MTO_SHIPMENT, mto_shipment)
+            return mto_shipment
+
+        return None
 
     @tag(PAYMENT_REQUEST, "createUpload")
     @task
@@ -490,14 +498,14 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
 
     @tag(MTO_SHIPMENT, "updateMTOShipmentStatus")
     @task
-    def update_mto_shipment_status(self):
+    def update_mto_shipment_status(self, overrides=None):
         # Get shipment we've previously stored in PrimeObjects
         mto_shipment = self.get_stored(MTO_SHIPMENT)
         if not mto_shipment:
-            return  # can't run this task
+            return None  # can't run this task
 
         # Generate fake payload based on the endpoint's required fields
-        payload = self.fake_request("/mto-shipments/{mtoShipmentID}/status", "patch", SUPPORT_API_KEY)
+        payload = self.fake_request("/mto-shipments/{mtoShipmentID}/status", "patch", SUPPORT_API_KEY, overrides)
 
         headers = {"content-type": "application/json", "If-Match": mto_shipment["eTag"]}
 
@@ -508,10 +516,13 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
             headers=headers,
             **self.user.cert_kwargs,
         )
-        resp, success = check_response(resp, "updateMTOShipmentStatus", payload)
+        mto_shipment, success = check_response(resp, "updateMTOShipmentStatus", payload)
 
         if success:
-            self.update_stored(MTO_SHIPMENT, mto_shipment, resp)
+            self.update_stored(MTO_SHIPMENT, mto_shipment, mto_shipment)
+            return mto_shipment
+
+        return None
 
     @tag(MOVE_TASK_ORDER, "createMoveTaskOrder")
     @task

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -234,7 +234,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         object_id = overrides.get("mtoShipmentID") if overrides else None
         mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
         if not mto_shipment:
-            logger.debug("createMTOServiceItem: ⛔️ No mto shipment found")
+            logger.debug("createMTOServiceItem: ⚠️ No mto_shipment found")
             return None
 
         overrides_local = {
@@ -267,7 +267,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
 
         move_task_order = self.get_stored(MOVE_TASK_ORDER, object_id)
         if not move_task_order:
-            logger.debug("createMTOShipment: ⛔️ No moveTaskOrder found")
+            logger.debug("createMTOShipment: ⚠️ No move_task_order found")
             return (
                 None  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
             )
@@ -498,7 +498,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         object_id = overrides.get("id") if overrides else None
         move_task_order = self.get_stored(MOVE_TASK_ORDER, object_id)
         if not move_task_order:
-            logger.error(f"⛔️ No move_task_order \n{move_task_order}")
+            logger.debug("updateMTOPostCounselingInformation: ⚠️ No move_task_order found")
             return  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
 
         payload = self.fake_request("/move-task-orders/{moveTaskOrderID}/post-counseling-info", "patch", PRIME_API_KEY)
@@ -539,7 +539,7 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
         object_id = overrides.get("id") if overrides else None
         mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
         if not mto_shipment:
-            logger.debug("updateMTOShipmentStatus: ⛔️ No mtoShipment found.")
+            logger.debug("updateMTOShipmentStatus: ⚠️ No mto_shipment found.")
             return None  # can't run this task
 
         # Generate fake payload based on the endpoint's required fields
@@ -565,7 +565,7 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
     def create_move_task_order(self):
         # Check that we have all required ID values for this endpoint:
         if not self.has_all_default_mto_ids():
-            logger.warning(f"⚠️ Missing createMoveTaskOrder IDs for environment {self.user.env}")
+            logger.debug(f"⚠️ Missing createMoveTaskOrder IDs for environment {self.user.env}")
             return
 
         overrides = {
@@ -620,7 +620,7 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
         mto_service_item = self.get_stored(MTO_SERVICE_ITEM, object_id)
         # if we don't have an mto shipment we can't run this task
         if not mto_service_item:
-            logger.debug("updateMTOServiceItemStatus: ⛔️ No mtoServiceItemFound")
+            logger.debug("updateMTOServiceItemStatus: ⚠️ No mto_service_item found")
             return None
 
         payload = self.fake_request("/mto-service-items/{mtoServiceItemID}/status", "patch", SUPPORT_API_KEY, overrides)
@@ -672,7 +672,7 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
         object_id = overrides.get("id") if overrides else None
         move_task_order = self.get_stored(MOVE_TASK_ORDER, object_id)
         if not move_task_order:
-            logger.error(f"⛔️ No move_task_order \n{move_task_order}")
+            logger.debug("getMoveTaskOrder: ⚠️ No move_task_order found")
             return
 
         headers = {"content-type": "application/json"}

--- a/tasks/prime_workflow.py
+++ b/tasks/prime_workflow.py
@@ -55,6 +55,18 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
         super().update_post_counseling_information()
         logger.info(f"{self.workflow_title} - Created move and completed counseling {self.current_move['id'][:8]}")
 
+        # Add a shipment and approve it
+        ship = super().create_mto_shipment()
+        print("the stored shipments after create 🛳: ", ship["id"], " ", ship["status"])
+
+        ship = super().update_mto_shipment_status(overrides={"status": "APPROVED"})
+        print("the stored shipments after update 🛳: ", ship["id"], " ", ship["status"])
+        logger.info(f"{self.workflow_title} - Created and approved a shipment {self.current_move['id'][:8]}")
+
+        # Add a service item and approve it
+
+        # Update the shipment
+
     # STORAGE FUNCTIONALITY
 
     def get_stored(self, object_key, object_id=None):

--- a/tasks/prime_workflow.py
+++ b/tasks/prime_workflow.py
@@ -51,7 +51,11 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
         self.workflow_title = "HHG Move Basic"
 
         # Move steps for this workflow
-        super().create_move_task_order()
+        move = super().create_move_task_order()
+        if not move:
+            logger.debug(f"{self.workflow_title} ⚠️ No move_task_order returned")
+            return
+
         super().update_post_counseling_information()
         logger.info(f"{self.workflow_title} - Created move and completed counseling {self.current_move['id'][:8]}")
 
@@ -82,7 +86,7 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
         )
 
     def update_shipment(self):
-        # Get the shipment from the mto
+        # Get the shipment from the mto (this is expecting just one shipment)
         ship = self.get_stored(MTO_SHIPMENT)
         overrides = {"id": ship["id"]}
         ship = super().update_mto_shipment(overrides)


### PR DESCRIPTION
## Description

This ticket adds more calls to the prime workflow. These are in the `prime_workflow.py` file.
Added workflow chunks for 
* Add shipment with doshut service and approve
* update shipment agent and address

To support that, did a bunch of cleanup and update on the tasks in `tasks/prime.py`
* Reduced logger printouts on successful calls
* Updated tasks to request a specific object from storage if called with overrides.
* Updated tasks to return the new object on successful call to the endpoint
* Documented all overrides in tasks

**This branch depends on the same named branch in the mymove repo**
Here is that PR : https://github.com/transcom/mymove/pull/5905

## Setup

- run Locust with make `load_test_prime_workflow`
- In the locust load test, select 25/10 for number of "users to simulate" and for "swarm rate".
- Check that all 7 new endpoints are hit as listed in the jira
- Check that there are ZERO failures. 

Unlike the discrete task based load testing, the prime_workflow taskset will **only test happy paths**. Therefore we expect no failures.
You should see hits to the above endpoints. You should see ZERO failures.

There are also tests setup for the storage aspect of prime workflow
You can run them with 
`pytest tasks/tests/test_prime_workflow.py` 

Should also have ZERO failures.


## References

* [Jira story](https://dp3.atlassian.net/browse/mb-6219) for this change.

