### PR TITLE
MB-6220 Add steps in prime workflow

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -293,6 +293,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         resp = self.client.post(
             prime_path("/mto-shipments"), data=json.dumps(payload), headers=headers, **self.user.cert_kwargs
         )
+
         mto_shipment, success = check_response(resp, "createMTOShipment", payload)
 
         if success:
@@ -337,8 +338,8 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         resp = self.client.post(
             prime_path("/payment-requests"), data=json.dumps(payload), headers=headers, **self.user.cert_kwargs
         )
-        payment_request, success = check_response(resp, "createPaymentRequest", payload)
 
+        payment_request, success = check_response(resp, "createPaymentRequest", payload)
         if success:
             self.add_stored(PAYMENT_REQUEST, payment_request)
             return payment_request

--- a/tasks/prime_workflow.py
+++ b/tasks/prime_workflow.py
@@ -61,6 +61,7 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
 
         self.add_shipment_with_doshut_service()
         self.update_shipment()
+        self.create_payment_request()
 
     def add_shipment_with_doshut_service(self):
         # Get a realistic primeEstimatedWeight
@@ -101,8 +102,19 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
 
         logger.info(f"{self.workflow_title} - Updated shipment and agent {self.current_move['id'][:8]}")
 
-    # STORAGE FUNCTIONALITY
+    def create_payment_request(self):
+        # Get service item from the mto and create payment request
+        service_item = self.get_stored(MTO_SERVICE_ITEM)
+        overrides = {"mtoServiceItemID": service_item["id"]}
+        request = super().create_payment_request(overrides)
 
+        # Create upload for payment request
+        overrides = {"id": request["id"]}
+        super().create_upload(overrides)
+
+        logger.info(f"{self.workflow_title} - Created payment request and upload {self.current_move['id'][:8]}")
+
+    # STORAGE FUNCTIONALITY
     def get_stored(self, object_key, object_id=None):
         """
         We only store one current move in the sequential workflow and keep it updated as we move through the workflow.

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -6,13 +6,14 @@ from datetime import datetime
 
 from faker import Faker
 from faker.providers.date_time import Provider as DateProvider  # extends BaseProvider
+from faker.providers.address.en_US import Provider as AddressProvider  # extends BaseProvider
 
 from .constants import DataType
 
 logger = logging.getLogger(__name__)
 
 
-class MilMoveProvider(DateProvider):
+class MilMoveProvider(AddressProvider, DateProvider):
     """ Faker Provider class for sending back customized MilMove data. """
 
     def __init__(self, *args, **kwargs):
@@ -85,6 +86,15 @@ class MilMoveProvider(DateProvider):
         """
         return self.random_element(self.safe_data["addresses"])
 
+    def safe_postal_code(self):
+        """
+        Returns a safe postal code as a string.
+        """
+        while True:
+            state = self.state_abbr(include_territories=False)
+            if state != "AK" and state != "HI":
+                return self.postalcode_in_state(state)
+
 
 class MilMoveData:
     """ Base class to return fake data to use in MilMove endpoints. """
@@ -103,7 +113,7 @@ class MilMoveData:
             DataType.STREET_ADDRESS: self.fake.safe_street_address,
             DataType.CITY: self.fake.city,
             DataType.STATE: self.fake.state_abbr,
-            DataType.POSTAL_CODE: self.fake.postalcode,
+            DataType.POSTAL_CODE: self.fake.safe_postal_code,
             DataType.COUNTRY: self.fake.country,
             DataType.DATE: self.fake.date,
             DataType.DATE_TIME: self.fake.iso_date_time,

--- a/utils/tests/test_fake_data.py
+++ b/utils/tests/test_fake_data.py
@@ -96,6 +96,11 @@ class TestMilMoveProvider:
         assert type(address) is str
         assert address in self.provider.safe_data["addresses"]
 
+    def test_safe_postal_code(self):
+        code = self.fake.safe_postal_code()
+        assert type(code) is str
+        assert re.match("^[0-9]{5}$", code)
+
 
 class TestMilMoveData:
     """ Tests the MilMoveData class and its methods. """


### PR DESCRIPTION
## Description

This PR adds two steps in the prime workflow: create payment request and create upload.

This also adds a fake data function to return a valid post code in the lower 48.

## Reviewer Notes

@shimonacarvalho created an accompanying PR to fix somethings in mymove. When testing this PR, please run the server against this PR: https://github.com/transcom/mymove/pull/5939 

## Setup

* Start the server locally `make server_run`
* in the milmove_load_testing repo, run ` make load_test_prime_workflow`

When to webpage pops up, enter 25 and 10.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6220) for this change.
