### PR TITLE
MB-5958 Add unit tests for utils.fields.ObjectField

### DIFF
--- a/utils/fields.py
+++ b/utils/fields.py
@@ -44,7 +44,7 @@ class BaseAPIField:
         :param value: str
         :return: bool
         """
-        if value and value not in self.discriminator_values:
+        if value and self.discriminator_values and value not in self.discriminator_values:
             return False
 
         return True  # default assumes the field is not discriminated

--- a/utils/tests/test_fields.py
+++ b/utils/tests/test_fields.py
@@ -91,7 +91,7 @@ class TestObjectField:
         """
         assert self.object_field.object_fields == []
         assert self.object_field.data_type == DataType.OBJECT
-        assert self.object_field.name == ""
+        assert self.object_field.name == "objectField"
         assert self.object_field.discriminator == ""
         assert self.object_field.discriminator_values == []
         assert self.object_field.required is False

--- a/utils/tests/test_fields.py
+++ b/utils/tests/test_fields.py
@@ -166,13 +166,15 @@ class TestObjectField:
         self.object_field.combine_fields(array_field, unique=True)
         assert len([field for field in self.object_field.object_fields if field.name == "arrayField"]) == 1
 
-        test_object = ObjectField(name="testObject")
-        test_object_subfield = BaseAPIField(name="testSentence", data_type=DataType.SENTENCE)
-        test_object.add_field(test_object_subfield)
+        combine_test = ObjectField(name="testObject")
+        combine_test_subfield = BaseAPIField(name="testSentence", data_type=DataType.SENTENCE)
+        combine_test.add_field(combine_test_subfield)
 
-        self.object_field.combine_fields(test_object)
-        assert test_object not in self.object_field.object_fields
-        assert all([test_field in self.object_field.object_fields for test_field in test_object.object_fields])
+        self.object_field.combine_fields(combine_test)
+
+        # Check that all of the fields in the `combine_test` ObjectField were successfully added to self.object_field:
+        assert all([field in self.object_field.object_fields for field in combine_test.object_fields])
+        assert combine_test not in self.object_field.object_fields
 
         with pytest.raises(TypeError):
             self.object_field.combine_fields("field string")

--- a/utils/tests/test_fields.py
+++ b/utils/tests/test_fields.py
@@ -190,8 +190,6 @@ class TestObjectField:
         """ Tests updating a list of fields to be 'required' """
         self.object_field.object_fields = []
 
-        required_fields = ["baseField", "randomField", "phoneField", "spaceField"]
-
         base_field = BaseAPIField(name="baseField", data_type=DataType.INTEGER)
         random_field = ArrayField(name="randomField")
         enum_field = EnumField(name="enumField")
@@ -204,7 +202,7 @@ class TestObjectField:
         assert enum_field.required is False
         assert space_field.required is False
 
-        self.object_field.update_required_fields(required_fields)
+        self.object_field.update_required_fields(["baseField", "randomField", "phoneField", "spaceField"])
 
         assert base_field.required is True
         assert random_field.required is True
@@ -310,6 +308,8 @@ class TestObjectFieldFaker:
     def setup_mocks(mocker):
         """
         Set up the mocked functions we need to run these tests. Must be called at the start of each test function.
+
+        :param mocker: the pytest mocker from the test case calling this function
         """
         # We have a 1/3 chance to skip non-required fields normally, so instead let's make it so every non-required
         # field is skipped unless require_all is used

--- a/utils/tests/test_fields.py
+++ b/utils/tests/test_fields.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-""" Tests utils/parsers.py """
+""" Tests utils/fields.py """
 import re
 
-from utils.fields import BaseAPIField, ArrayField, EnumField
+import pytest
+from faker.generator import Generator
+
+from utils.fields import BaseAPIField, ArrayField, EnumField, ObjectField
 from utils.constants import DataType
 from utils.fake_data import MilMoveProvider, MilMoveData
-from faker.generator import Generator
 
 
 class TestBaseAPIField:
@@ -69,3 +71,106 @@ class TestArrayField:
         overrides = {"phoneNumbers": [{"phoneNumber": "test 1"}, {"phoneNumber": "test 2"}]}
         array2 = self.array_field.generate_fake_data(self.faker, overrides=overrides)
         assert array2[0] == "test 1" and array2[1] == "test 2"
+
+
+class TestObjectField:
+    """ Tests the ObjectField class and its methods. """
+
+    @classmethod
+    def setup_class(cls):
+        """ Initialize the ObjectField that will be tested. """
+        cls.object_field = ObjectField()
+        cls.faker = MilMoveData()
+
+    def test_init(self):
+        """
+        Tests that the ObjectField was initialized with the right values, including the logic from the __post_init__
+        method.
+        """
+        assert self.object_field.object_fields == []
+        assert self.object_field.data_type == DataType.OBJECT
+        assert self.object_field.name == ""
+        assert self.object_field.discriminator == ""
+        assert self.object_field.discriminator_values == []
+        assert self.object_field.required is False
+
+    def test_add_field(self):
+        """ Tests adding one field to the ObjectField instance's list of sub-fields. """
+        self.object_field.object_fields = []
+
+        test_field = BaseAPIField(name="baseField", data_type=DataType.INTEGER)
+        self.object_field.add_field(test_field)
+        assert test_field in self.object_field.object_fields
+
+        # Testing that we can add another ObjectField to this ObjectField's list of subfields,
+        # and that the subfields of the two Objects do not merge:
+        test_object = ObjectField(name="testObject")
+        test_object_subfield = BaseAPIField(name="testSentence", data_type=DataType.SENTENCE)
+        test_object.add_field(test_object_subfield)
+        self.object_field.add_field(test_object)
+        assert test_object in self.object_field.object_fields
+        assert test_object_subfield in test_object.object_fields
+        assert test_object_subfield not in self.object_field.object_fields
+
+        test_field_duplicate = BaseAPIField(name="baseField", data_type=DataType.DATE)
+        self.object_field.add_field(test_field_duplicate)  # unique=False, so duplicates should be allowed
+        assert test_field_duplicate in self.object_field.object_fields
+        assert test_field in self.object_field.object_fields  # make sure the original is still in the list
+        assert test_field.name == test_field_duplicate.name
+
+        test_object_duplicate = BaseAPIField(name="testObject", data_type=DataType.SENTENCE)
+        self.object_field.add_field(test_object_duplicate, unique=True)
+        assert test_object_duplicate not in self.object_field.object_fields
+        assert test_object in self.object_field.object_fields
+
+    def test_add_fields(self):
+        """ Tests adding multiple fields at once to the the ObjectField's list of sub-fields. Calls add_field. """
+        self.object_field.object_fields = []
+
+        field_list = [
+            BaseAPIField(name="baseField", data_type=DataType.INTEGER),
+            BaseAPIField(name="testSentence", data_type=DataType.SENTENCE),
+        ]
+        self.object_field.add_fields(field_list)
+        assert all([field in self.object_field.object_fields for field in field_list])
+
+        duplicate_field_list = [BaseAPIField(name="baseField", data_type=DataType.PHONE)]
+        self.object_field.add_fields(duplicate_field_list)  # unique=False
+        assert all([field in self.object_field.object_fields for field in duplicate_field_list])
+        assert all([field in self.object_field.object_fields for field in field_list])
+        assert len([field for field in self.object_field.object_fields if field.name == "baseField"]) == 2
+
+        unique_field = BaseAPIField(name="uniqueField", data_type=DataType.COUNTRY)
+        unique_field_list = [BaseAPIField(name="testSentence", data_type=DataType.EMAIL), unique_field]
+        self.object_field.add_fields(unique_field_list, unique=True)
+        assert len([field for field in self.object_field.object_fields if field.name == "testSentence"]) == 1
+        assert unique_field in self.object_field.object_fields
+
+    def test_combine_fields(self):
+        """
+        Tests combining fields with this ObjectField.
+        Expected behavior:
+         - If the field is a subclass of BaseAPIField, but not another ObjectField, it should simply add the field to
+           this ObjectField's list of sub-fields.
+         - If the field is another ObjectField instance, it should add all of the sub-fields of the ObjectField to this
+           ObjectField's list of sub-fields.
+        """
+        self.object_field.object_fields = []
+
+        array_field = ArrayField(name="arrayField")
+        self.object_field.combine_fields(array_field)
+        assert array_field in self.object_field.object_fields
+
+        self.object_field.combine_fields(array_field, unique=True)
+        assert len([field for field in self.object_field.object_fields if field.name == "arrayField"]) == 1
+
+        test_object = ObjectField(name="testObject")
+        test_object_subfield = BaseAPIField(name="testSentence", data_type=DataType.SENTENCE)
+        test_object.add_field(test_object_subfield)
+
+        self.object_field.combine_fields(test_object)
+        assert test_object not in self.object_field.object_fields
+        assert all([test_field in self.object_field.object_fields for test_field in test_object.object_fields])
+
+        with pytest.raises(TypeError):
+            self.object_field.combine_fields("field string")

--- a/utils/tests/test_fields.py
+++ b/utils/tests/test_fields.py
@@ -80,7 +80,6 @@ class TestObjectField:
     def setup_class(cls):
         """ Initialize the ObjectField that will be tested. """
         cls.object_field = ObjectField()
-        cls.faker = MilMoveData()
 
     def test_init(self):
         """
@@ -174,3 +173,47 @@ class TestObjectField:
 
         with pytest.raises(TypeError):
             self.object_field.combine_fields("field string")
+
+    def test_get_field(self):
+        """ Tests retrieving a given field, by name, from this ObjectField's list of sub-fields. """
+        self.object_field.object_fields = []
+
+        base_field = BaseAPIField(name="baseField", data_type=DataType.INTEGER)
+        self.object_field.add_field(base_field)
+        returned_field = self.object_field.get_field("baseField")
+        assert returned_field == base_field
+
+    def test_update_required_fields(self):
+        """ Tests updating a list of fields to be 'required' """
+        self.object_field.object_fields = []
+
+        required_fields = ["baseField", "randomField", "phoneField", "spaceField"]
+
+        base_field = BaseAPIField(name="baseField", data_type=DataType.INTEGER)
+        random_field = ArrayField(name="randomField")
+        enum_field = EnumField(name="enumField")
+        space_field = ObjectField(name="spaceField")
+
+        self.object_field.add_fields([base_field, random_field, enum_field, space_field])
+
+        assert base_field.required is False
+        assert random_field.required is False
+        assert enum_field.required is False
+        assert space_field.required is False
+
+        self.object_field.update_required_fields(required_fields)
+
+        assert base_field.required is True
+        assert random_field.required is True
+        assert enum_field.required is False
+        assert space_field.required is True
+
+    def test_add_discriminator_value(self):
+        """ Tests adding a discriminator for sub-fields. """
+        # Using the four fields set previous in test_update_required_fields
+        assert len(self.object_field.object_fields) > 0
+
+        discriminator_value = "discriminator"
+        self.object_field.add_discriminator_value(discriminator_value)
+        assert discriminator_value in self.object_field.discriminator_values
+        assert all([discriminator_value in field.discriminator_values for field in self.object_field.object_fields])

--- a/utils/tests/test_parsers.py
+++ b/utils/tests/test_parsers.py
@@ -105,13 +105,6 @@ class TestAPIParser:
         """
         assert self.parser.get_definition(name) == definition
 
-    def test_generate_fake_request(self):
-        """
-
-        :return:
-        """
-        # TODO
-
     @pytest.mark.parametrize("path,method", [("/orchards", "post")])
     def test__process_request_body(self, path, method):
         """

--- a/utils/tests/test_parsers.py
+++ b/utils/tests/test_parsers.py
@@ -105,6 +105,13 @@ class TestAPIParser:
         """
         assert self.parser.get_definition(name) == definition
 
+    def test_generate_fake_request(self):
+        """
+
+        :return:
+        """
+        # TODO
+
     @pytest.mark.parametrize("path,method", [("/orchards", "post")])
     def test__process_request_body(self, path, method):
         """


### PR DESCRIPTION
## Description

This PR adds unit tests for all of the methods in the ObjectField class. It also fixes some bugs encountered along the way.

## Setup

To run only the new tests:

```sh
pytest -v -k TestObjectField utils/tests/test_fields.py
```

And to run all tests:

```sh
pytest
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5958) for this change.
