### PR TITLE
MB-7103 Rename moveOrder to order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,12 @@ repos:
         args: ['--line-length', '120']
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-ast
       - id: check-json
@@ -30,7 +30,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.25.0
+    rev: v0.27.1
     hooks:
       - id: markdownlint
         entry: markdownlint --ignore .github/*.md

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -174,7 +174,7 @@ class PrimeDataStorageMixin:
             self.default_mto_ids["contractorID"] = move_details.get(
                 "contractorID", self.default_mto_ids["contractorID"]
             )
-            if order_details := move_details.get("moveOrder"):
+            if order_details := move_details.get("order"):
                 self.default_mto_ids["uploadedOrdersID"] = order_details.get(
                     "uploadedOrdersID", self.default_mto_ids["uploadedOrdersID"]
                 )
@@ -578,7 +578,7 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
             "status": "SUBMITTED",
             # If this date is set here, the status will not properly transition to APPROVED
             "availableToPrimeAt": None,
-            "moveOrder": {
+            "order": {
                 "status": "APPROVED",
                 # We need these objects to exist
                 "destinationDutyStationID": self.default_mto_ids["destinationDutyStationID"],

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -683,7 +683,7 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
 
         resp = self.client.get(
             support_path(f"/move-task-orders/{move_task_order['id']}"),
-            name=support_path("move-task-orders/{moveTaskOrderID}"),
+            name=support_path("/move-task-orders/{moveTaskOrderID}"),
             headers=headers,
             **self.user.cert_kwargs,
         )

--- a/tasks/prime_workflow.py
+++ b/tasks/prime_workflow.py
@@ -65,7 +65,7 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
 
     def add_shipment_with_doshut_service(self):
         # Get a realistic primeEstimatedWeight
-        estimated_weight = int(98 / 100 * self.current_move["moveOrder"]["entitlement"]["totalWeight"])
+        estimated_weight = int(98 / 100 * self.current_move["order"]["entitlement"]["totalWeight"])
 
         # Add a shipment and approve it
         overrides = {"primeEstimatedWeight": estimated_weight}

--- a/tasks/tests/test_prime.py
+++ b/tasks/tests/test_prime.py
@@ -195,7 +195,7 @@ class TestPrimeDataStorageMixin:
                 "id": "1",
                 "status": 200,
                 "json": {
-                    "moveOrder": {
+                    "order": {
                         "uploadedOrdersID": "upload1",
                         "destinationDutyStationID": "",  # purposefully blank, will not count for end of loop
                         "originDutyStationID": "origin1",
@@ -206,7 +206,7 @@ class TestPrimeDataStorageMixin:
                 "id": "2",
                 "status": 200,
                 "json": {
-                    "moveOrder": {
+                    "order": {
                         "destinationDutyStationID": "destination2",
                         "originDutyStationID": "origin2",
                     }
@@ -218,7 +218,7 @@ class TestPrimeDataStorageMixin:
                 "json": {
                     # these values should not be used because they all should have been set previously
                     "contractorID": "contractor3",
-                    "moveOrder": {
+                    "order": {
                         "uploadedOrdersID": "upload3",
                     },
                 },
@@ -245,7 +245,7 @@ class TestPrimeDataStorageMixin:
         test_moves_after = [
             {
                 "contractorID": "contractor4",
-                "moveOrder": {
+                "order": {
                     "uploadedOrdersID": "upload4",
                     "destinationDutyStationID": "destination4",
                     "originDutyStationID": "origin4",

--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -436,7 +436,7 @@ class SupportAPIParser(PrimeAPIParser):
         if path == "/move-task-orders" and method == "post":
 
             move_task_order = request_data
-            move_orders = request_data["moveOrder"]
+            move_orders = request_data["order"]
             customer = move_orders["customer"]
             entitlement = move_orders["entitlement"]
 
@@ -445,7 +445,7 @@ class SupportAPIParser(PrimeAPIParser):
             move_task_order.pop("paymentRequests", None)
             move_task_order.pop("mtoServiceItems", None)
 
-            move_task_order.pop("moveOrderID", None)  # moveOrderID will be returned on creation
+            move_task_order.pop("orderID", None)  # orderID will be returned on creation
 
             # Cannot create certain nested objects with this endpoint, instead the caller should pass in an ID
             # (in overrides)


### PR DESCRIPTION
## Description

PR to align with the updates in MilMove to change the "MoveOrder" object to be called "Order." Chore for this work: https://dp3.atlassian.net/browse/MB-7103

## Setup

Review after https://github.com/transcom/mymove/pull/6120 is merged.

In the `mymove` directory:
```sh
make server_run
```

Then in `milmove_load_testing`:
```sh
make load_test_prime
```

Select ~10 users at whatever spawn rate you wish. Verify that most responses are successful, particularly for the support task to create MTOs. (Other tasks, like the MTO Service Items and some support status endpoints have known issues. Their failures are not blockers.)

## Code Review Verification Steps

* [x] Request review from a member of a different team.
