### PR TITLE
MB-6698 Fix updateMTOServiceItem 500 errors during load testing

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -477,8 +477,19 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
                 "[DDDSIT, DOPSIT]"
             )
             return
+
         payload = self.fake_request(
-            "/mto-service-items/{mtoServiceItemID}", "patch", overrides={"id": mto_service_item["id"]}
+            "/mto-service-items/{mtoServiceItemID}",
+            "patch",
+            overrides={
+                "id": mto_service_item["id"],
+                "sitDestinationFinalAddress": {
+                    "id": mto_service_item["sitDestinationFinalAddress"]["id"]
+                    if mto_service_item.get("sitDestinationFinalAddress")
+                    and mto_service_item["sitDestinationFinalAddress"].get("id")
+                    else ZERO_UUID,
+                },
+            },
         )
 
         headers = {"content-type": "application/json", "If-Match": mto_service_item["eTag"]}

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -95,6 +95,12 @@ class MilMoveProvider(AddressProvider, DateProvider):
             if state != "AK" and state != "HI":
                 return self.postalcode_in_state(state)
 
+    def safe_uuid(self):
+        """
+        Returns an empty uuid as a string.
+        """
+        return "00000000-0000-0000-0000-000000000000"
+
 
 class MilMoveData:
     """ Base class to return fake data to use in MilMove endpoints. """
@@ -121,7 +127,7 @@ class MilMoveData:
             DataType.SENTENCE: self.fake.sentence,
             DataType.BOOLEAN: self.fake.boolean,
             DataType.INTEGER: self.fake.random_number,
-            DataType.UUID: self.fake.uuid4,
+            DataType.UUID: self.fake.safe_uuid,
         }
 
     def get_random_choice(self, choices):

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -8,7 +8,7 @@ from faker import Faker
 from faker.providers.date_time import Provider as DateProvider  # extends BaseProvider
 from faker.providers.address.en_US import Provider as AddressProvider  # extends BaseProvider
 
-from .constants import DataType
+from .constants import DataType, ZERO_UUID
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class MilMoveProvider(AddressProvider, DateProvider):
         """
         Returns an empty uuid as a string.
         """
-        return "00000000-0000-0000-0000-000000000000"
+        return ZERO_UUID
 
 
 class MilMoveData:

--- a/utils/tests/test_fake_data.py
+++ b/utils/tests/test_fake_data.py
@@ -101,6 +101,9 @@ class TestMilMoveProvider:
         assert type(code) is str
         assert re.match("^[0-9]{5}$", code)
 
+    def test_safe_uuid(self):
+        assert self.fake.safe_uuid() == "00000000-0000-0000-0000-000000000000"
+
 
 class TestMilMoveData:
     """ Tests the MilMoveData class and its methods. """


### PR DESCRIPTION
## Description

Previously, load testing would generate random UUID's for tests. This led to foreign key errors being through when calling `updateMTOServiceItem` and `createMTOServiceItem`. To fix this, the faker now returns an empty uuid. The empty uuid is ignored by swagger/handlers and they won't be updated now. 

## Setup

To test that this works, run load testing and confirm that no 500 errors appear for 
`PATCH | /prime/v1/mto-service-items/{mtoServiceItemID}` and `POST | /prime/v1/mto-service-items`.

To run load testing run `make db_dev_e2e_populate` and `make server_run` in the mymove repo. Then run `make load_test_prime` in the load testing repo.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-6698](https://dp3.atlassian.net/browse/MB-6698) for this change.
* [MB-6697](https://dp3.atlassian.net/browse/MB-6697) for this change.
