### PR TITLE
MB-7225 Stop generating negative crate dimensions

### DIFF
--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -435,7 +435,7 @@ class PrimeAPIParser(APIParser):
         :return: tup(item_dim int, crate_dim int)
         """
         if item_dim <= 0:
-            item_dim += 1
+            item_dim = 1
         if item_dim >= crate_dim:
             if crate_dim <= 1:
                 crate_dim = 2

--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -436,10 +436,8 @@ class PrimeAPIParser(APIParser):
         """
         if item_dim <= 0:
             item_dim = 1
-        if item_dim >= crate_dim:
-            if crate_dim <= 1:
-                crate_dim = 2
-            item_dim = crate_dim - 1
+        if crate_dim <= item_dim:
+            crate_dim = item_dim + 1
         return item_dim, crate_dim
 
 

--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -413,14 +413,34 @@ class PrimeAPIParser(APIParser):
                 item_details = request_data.get("item")
                 crate_details = request_data.get("crate")
                 if item_details and crate_details:
-                    if item_details["length"] >= crate_details["length"]:
-                        item_details["length"] = crate_details["length"] - 1
+                    item_details["length"], crate_details["length"] = self.normalize_crate_dimensions(
+                        item_details["length"], crate_details["length"]
+                    )
+                    item_details["width"], crate_details["width"] = self.normalize_crate_dimensions(
+                        item_details["width"], crate_details["width"]
+                    )
+                    item_details["height"], crate_details["height"] = self.normalize_crate_dimensions(
+                        item_details["height"], crate_details["height"]
+                    )
 
-                    if item_details["width"] >= crate_details["width"]:
-                        item_details["width"] = crate_details["width"] - 1
+    @staticmethod
+    def normalize_crate_dimensions(item_dim: int, crate_dim: int) -> (int, int):
+        """
+        Check that the item dimensions are always smaller than the crate dimensions (since the item has to fit inside
+        it). Additionally, ensure that both dimensions are greater than 0 so that we don't encounter any errors from
+        MilMove attempting to manipulate zero or negative numbers. Returns the normalized versions of both values.
 
-                    if item_details["height"] >= crate_details["height"]:
-                        item_details["height"] = crate_details["height"] - 1
+        :param item_dim: int
+        :param crate_dim: int
+        :return: tup(item_dim int, crate_dim int)
+        """
+        if item_dim <= 0:
+            item_dim += 1
+        if item_dim >= crate_dim:
+            if crate_dim <= 1:
+                crate_dim = 2
+            item_dim = crate_dim - 1
+        return item_dim, crate_dim
 
 
 class SupportAPIParser(PrimeAPIParser):

--- a/utils/tests/test_parsers.py
+++ b/utils/tests/test_parsers.py
@@ -10,7 +10,7 @@ from utils.base import ImplementationError
 from utils.constants import STATIC_FILES, DataType, ARRAY_MIN, ARRAY_MAX
 from utils.fake_data import MilMoveData
 from utils.fields import APIEndpointBody, ObjectField, BaseAPIField, ArrayField, EnumField
-from utils.parsers import APIParser
+from utils.parsers import APIParser, PrimeAPIParser
 from .params_parsers import *
 
 
@@ -246,3 +246,31 @@ class TestAPIParser:
     def test__approximate_str_type(self, field_name, expected_type):
         """ Test that field names are being used to approximate the closest data type. """
         assert self.parser._approximate_str_type(field_name) == expected_type
+
+
+class TestPrimeAPIParser:
+    """ Tests some of the custom methods on the PrimeAPIParser class """
+
+    @classmethod
+    def setup_class(cls):
+        """ Initialize the APIParser that will be tested. """
+        cls.parser = PrimeAPIParser()
+
+    @pytest.mark.parametrize(
+        "input_dimensions,expected_dimensions",
+        [
+            # (input=(item_dim, crate_dim), expected=(item_dim, crate_dim))
+            ((0, 0), (1, 2)),
+            ((-40, 5), (1, 5)),
+            ((20, -15), (20, 21)),
+            ((3, 3), (3, 4)),
+            ((8, 16), (8, 16)),
+        ],
+    )
+    def test_normalize_crate_dimensions(self, input_dimensions, expected_dimensions):
+        """
+        Tests that normalize_crate_dimensions always returns values that are greater than 0, and that the item is
+        smaller than the crate.
+        """
+        output_dimensions = self.parser.normalize_crate_dimensions(*input_dimensions)
+        assert output_dimensions == expected_dimensions


### PR DESCRIPTION
## Description

For the Domestic Crating MTO Service Items, the API parser has to generate a set of dimensions for the item and a set of dimensions for the crate that item is going to be put in. These values are all random integers, but we have to make sure the item is smaller than the crate for the endpoint to work.

With the old code, we would just set the item value to be the same as the crate's - 1 so that we knew it was smaller:
```python
if item <= crate:
    item = crate - 1
```

However, in rare cases, the generator would pick 0 as a value for one of the crate's dimensions! In that case the item, would get -1! We don't want to break the rules of space and time with this code, so I've changed the above code to also make sure both values are above 0.

## Setup

To test this in action, run load testing for a while and verify that you don't see ANY 500 errors from `createMTOServiceItem`. You may also run the unit tests for this function:

```sh
pytest -v -k TestPrimeAPIParser
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7225) for this change.
