### PR TITLE
MB-7400 Add a valid TAC override to create MTO

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -591,6 +591,7 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
             "availableToPrimeAt": None,
             "order": {
                 "status": "APPROVED",
+                "tac": "F8J1",
                 # We need these objects to exist
                 "destinationDutyStationID": self.default_mto_ids["destinationDutyStationID"],
                 "originDutyStationID": self.default_mto_ids["originDutyStationID"],


### PR DESCRIPTION
## Description

This PR adds an override for a valid TAC to the request payload for `create_move_task_order`. Note that it also depends on the changes in https://github.com/transcom/mymove/pull/6288 to fully fix the issue (there were other validation errors in the backend).

## Setup

Wait for https://github.com/transcom/mymove/pull/6288 to be merged, or modify line 447 in `utils/parsers.py` (the `SupportAPIParser`) to point at branch `sw-mb-7400-add-fields-to-create-mto` instead of `master`. You'll also need to checkout this branch in your mymove repo.

Run your `mymove` server:

```sh
make db_dev_e2e_populate server_run
```

Then, in `milmove_load_testing`, run the `prime_workflow` test:

```sh
make load_test_prime_workflow
```

Verify that every task succeeds.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7400) for this change.
