### PR TITLE
[MB-7254] GHC API load testing getMove endpoint for SC and TOO

### DIFF
--- a/locustfiles/office.py
+++ b/locustfiles/office.py
@@ -4,14 +4,14 @@ from locust import HttpUser, between
 
 from utils.hosts import MilMoveHostMixin, MilMoveDomain
 from utils.parsers import GHCAPIParser
-from tasks import OfficeTasks
+from tasks import ServicesCounselorTasks, TOOTasks
 
 ghc_api = GHCAPIParser()
 
 
-class OfficeUser(MilMoveHostMixin, HttpUser):
+class ServicesCounselorUser(MilMoveHostMixin, HttpUser):
     """
-    Tests the MilMove Office app.
+    Tests the MilMove Office app with the Services Counselor role.
     """
 
     local_protocol = "http"
@@ -21,5 +21,21 @@ class OfficeUser(MilMoveHostMixin, HttpUser):
     # This attribute is used for generating fake requests when hitting the GHC API:
     parser = ghc_api
 
-    wait_time = between(1, 9)
-    tasks = {OfficeTasks: 1}
+    wait_time = between(0.25, 9)
+    tasks = {ServicesCounselorTasks: 1}
+
+
+class TOOUser(MilMoveHostMixin, HttpUser):
+    """
+    Tests the MilMove Office app with the TOO role.
+    """
+
+    local_protocol = "http"
+    local_port = "8080"
+    domain = MilMoveDomain.OFFICE
+
+    # This attribute is used for generating fake requests when hitting the GHC API:
+    parser = ghc_api
+
+    wait_time = between(0.25, 9)
+    tasks = {TOOTasks: 1}

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .office import OfficeTasks  # noqa
+from .office import ServicesCounselorTasks, TOOTasks  # noqa
 from .milmove import MilMoveTasks  # noqa
 from .prime import PrimeTasks, SupportTasks  # noqa
 from .prime_workflow import PrimeWorkflowTasks  # noqa

--- a/tasks/office.py
+++ b/tasks/office.py
@@ -2,10 +2,19 @@
 """ TaskSets and tasks for the Office interface. """
 import logging
 import json
+import random
+from typing import Dict
 
 from locust import task, tag
 
-from utils.constants import MOVE
+from utils.constants import (
+    MOVE,
+    MOVE_TASK_ORDER,
+    MTO_SERVICE_ITEM,
+    MTO_SHIPMENT,
+    QUEUES,
+    PAYMENT_REQUEST,
+)
 from .base import check_response, LoginTaskSet, ParserTaskMixin
 
 logger = logging.getLogger(__name__)
@@ -15,9 +24,82 @@ def ghc_path(url: str) -> str:
     return f"/ghc/v1{url}"
 
 
-class OfficeTasks(LoginTaskSet, ParserTaskMixin):
+class OfficeDataStorageMixin:
     """
-    Set of tasks that can be called for the MilMove Office interface.
+    TaskSet mixin used to store data from the GHC API during load testing so that it can be passed around and reused.
+    We store a number of objects in a local store that can be requested by tasks.
+    The tasks then hit an endpoint and call add or replace to update our local store with a list of viable objects.
+    This mixin allows storing multiple items of each kind.
+    """
+
+    DATA_LIST_MAX: int = 50
+    local_store: Dict[str, list] = {
+        MOVE_TASK_ORDER: [],
+        MTO_SHIPMENT: [],
+        MTO_SERVICE_ITEM: [],
+        PAYMENT_REQUEST: [],
+    }  # data stored will be shared among class instances thanks to mutable dict
+
+    def get_stored(self, object_key, *args, **kwargs):
+        """
+        Given an object_key that represents an object type from the MilMove app, returns an object of that type from the
+        list.
+
+        :param object_key: str in [MOVE_TASK_ORDER, MTO_SHIPMENT, MTO_AGENT, MTO_SERVICE_ITEM, PAYMENT_REQUEST]
+        """
+        data_list = self.local_store[object_key]
+
+        if len(data_list) > 0:  # otherwise we return None
+            return random.choice(data_list)
+
+    def add_stored(self, object_key, object_data):
+        """
+        Adds data to the list for the object key provided. Also checks if the list is already at the max number of
+        elements, and if so, it randomly removes 1 to MAX number of elements so that the cycle can start again (and so
+        we don't hog too much memory).
+
+        :param object_key: str in [MOVE_TASK_ORDER, MTO_SHIPMENT, MTO_AGENT, MTO_SERVICE_ITEM, PAYMENT_REQUEST]
+        :param object_data: JSON/dict
+        :return: None
+        """
+        data_list = self.local_store[object_key]
+        logger.info(f"size of {object_key} {len(data_list)}")
+
+        if len(data_list) >= self.DATA_LIST_MAX:
+            num_to_delete = random.randint(1, self.DATA_LIST_MAX)
+            del data_list[:num_to_delete]
+
+        # Some creation endpoint auto-create multiple objects and return an array,
+        # but each object in the array should still be considered individually here:
+        if isinstance(object_data, list):
+            data_list.extend(object_data)
+        else:
+            data_list.append(object_data)
+
+    def update_stored(self, object_key, old_data, new_data):
+        """
+        Given an object key, replaces a stored object in the local store with a new updated object.
+
+        :param object_key: str in [MOVE_TASK_ORDER, MTO_SHIPMENT, MTO_AGENT, MTO_SERVICE_ITEM, PAYMENT_REQUEST]
+        :param old_data: JSON/dict
+        :param new_data: JSON/dict
+        :return: None
+        """
+        data_list = self.local_store[object_key]
+
+        # Remove all instances of the stored object, in case multiples were added erroneously:
+        while True:
+            try:
+                data_list.remove(old_data)
+            except ValueError:
+                break  # this means we finally cleared the list
+
+        data_list.append(new_data)
+
+
+class ServicesCounselorTasks(OfficeDataStorageMixin, LoginTaskSet, ParserTaskMixin):
+    """
+    Set of tasks that can be called for the MilMove Office interface with the Services Counselor role.
     """
 
     def on_start(self):
@@ -26,7 +108,7 @@ class OfficeTasks(LoginTaskSet, ParserTaskMixin):
         """
         super().on_start()  # sets the csrf token
 
-        resp = self._create_login(user_type="PPM office", session_token_name="office_session_token")
+        resp = self._create_login(user_type="Services Counselor office", session_token_name="office_session_token")
         if resp.status_code != 200:
             self.interrupt()  # if we didn't successfully log in, there's no point attempting the other tasks
 
@@ -50,14 +132,104 @@ class OfficeTasks(LoginTaskSet, ParserTaskMixin):
         Fetches a single move
         """
         # If id was provided, get that specific one. Else get any stored one.
-        locator = overrides.get("locator") if overrides else "COMBOS"
-
+        object_id = overrides.get("id") if overrides else None
+        move = self.get_stored(MOVE_TASK_ORDER, object_id)
         headers = {"content-type": "application/json"}
 
         resp = self.client.get(
-            ghc_path(f"/move/{locator}"),
+            ghc_path(f"/move/{move['locator']}"),
             name=ghc_path("/move/{locator}"),
             headers=headers,
             **self.user.cert_kwargs,
         )
         new_mto, success = check_response(resp, "getMove")
+        logger.info(f"getMove {new_mto}")
+
+    @tag(QUEUES, "getServicesCounselingQueue")
+    @task
+    def get_moves_queue(self, overrides=None):
+        """
+        Fetches a list of paginated moves
+        """
+
+        headers = {"content-type": "application/json"}
+
+        resp = self.client.get(
+            ghc_path("/queues/counseling?perPage=50"),
+            name=ghc_path("/queues/counseling"),
+            headers=headers,
+            **self.user.cert_kwargs,
+        )
+        moves, success = check_response(resp, "getServicesCounselingQueue")
+        logger.info(f"found {moves['totalCount']} services counseling moves")
+        # these are not full move models and will be those in needs counseling status
+        self.add_stored(MOVE_TASK_ORDER, moves["queueMoves"])
+
+
+class TOOTasks(OfficeDataStorageMixin, LoginTaskSet, ParserTaskMixin):
+    """
+    Set of tasks that can be called for the MilMove Office interface with the TOO role.
+    """
+
+    def on_start(self):
+        """
+        Creates a login right at the start of the TaskSet and stops task execution if the login fails.
+        """
+        super().on_start()  # sets the csrf token
+
+        resp = self._create_login(user_type="TOO office", session_token_name="office_session_token")
+        if resp.status_code != 200:
+            self.interrupt()  # if we didn't successfully log in, there's no point attempting the other tasks
+
+    @task
+    def get_user_info(self):
+        """
+        Gets the user info for the currently logged in user.
+        """
+        resp = self.client.get("/internal/users/logged_in")
+        try:
+            json_body = json.loads(resp.content)
+        except json.JSONDecodeError:
+            logger.exception("Non-JSON response")
+        else:
+            logger.info(f"ℹ️ User email: {json_body.get('email', 'None')}")
+
+    @tag(MOVE, "getMove")
+    @task
+    def get_move(self, overrides=None):
+        """
+        Fetches a single move
+        """
+        # If id was provided, get that specific one. Else get any stored one.
+        object_id = overrides.get("id") if overrides else None
+        move = self.get_stored(MOVE_TASK_ORDER, object_id)
+
+        headers = {"content-type": "application/json"}
+
+        resp = self.client.get(
+            ghc_path(f"/move/{move['locator']}"),
+            name=ghc_path("/move/{locator}"),
+            headers=headers,
+            **self.user.cert_kwargs,
+        )
+        new_mto, success = check_response(resp, "getMove")
+        logger.info(f"getMove {new_mto}")
+
+    @tag(QUEUES, "getMovesQueue")
+    @task
+    def get_moves_queue(self, overrides=None):
+        """
+        Fetches a list of paginated moves
+        """
+
+        headers = {"content-type": "application/json"}
+
+        resp = self.client.get(
+            ghc_path("/queues/moves?perPage=50"),
+            name=ghc_path("/queues/moves"),
+            headers=headers,
+            **self.user.cert_kwargs,
+        )
+        moves, success = check_response(resp, "getMovesQueue")
+        logger.info(f"found {moves['totalCount']} TOO moves")
+        self.add_stored(MOVE_TASK_ORDER, moves["queueMoves"])

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -28,6 +28,7 @@ MTO_AGENT = "mtoAgent"
 MTO_SHIPMENT = "mtoShipment"
 MTO_SERVICE_ITEM = "mtoServiceItem"
 PAYMENT_REQUEST = "paymentRequest"
+QUEUES = "queues"
 
 
 class DataType(ValueEnum):


### PR DESCRIPTION
## Description

This PR expands the GHC API testing to incorporate distinct Services Counselor and TOO office users making requests to the [getMove endpoint](http://milmovelocal:3000/swagger-ui/ghc.html#/move/getMove).

I incorporated the same kind of local storage that the Prime uses as a mixin to both set of office user tasks.  I added tasks to request the queue data for each user type, which will populate the local storage with move data in different statuses.  There is overlap from the Services Counselor moves and TOO moves for those in the `SERVICE COUNSELING COMPLETED` status so what ends up in the local store will naively contain duplicates at this time.

To make things more realistic, I did work on randomizing creation of move data for the services counselor user because the seed only had 1 or 2 moves.  That [PR will also need review in the mymove repo](https://github.com/transcom/mymove/pull/6624).  For my load test I bumped up the seed data to create ~200 moves.

While simulating hundreds of users I did start to see failures with a server error of too many open files.  There is a default system/session soft limit of 256 open files.  You can see this by running `ulimit -a` in your terminal.  Once I raised it with with `ulimit -n 2048` I now longer saw failures when load testing a high number of users.  This limit may be per terminal tab so it may not apply across sessions, so set it in the window where you want to run your server.

## Reviewer Notes

We should likely be seeing some failures if we had authorization on this endpoint to make sure a role such as services counselor can not view a move in say Approved or Approvals Requested or a TOO cannot view a move in Needs Service Counseling.

Both SC and TOO users are in the same default GBLOC so there is no chance of requesting one outside but we should try to introduce that maybe by adding USMC users too.

We could also introduce non-existent locator requests, the current exception now is just when no moves exist yet in the local store lookup before a queue response is added.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

From the [new branch in mymove](https://github.com/transcom/mymove/pull/6624) with the devseed changes, editing the loop count to create the desired amount of moves.
```sh
make db_dev_e2e_populate
make server_run
```

From the milmove_load_testing repo:
```sh
make local_docker_build
make local_docer_office_up
```

In locust I simulated 500 users that spawned 5 new users/per second.

<img width="1076" alt="Screen Shot 2021-05-14 at 11 14 47 AM" src="https://user-images.githubusercontent.com/52669884/118291732-e6d11e00-b4a5-11eb-8994-a9a1a30a00fb.png">
<img width="1124" alt="Screen Shot 2021-05-14 at 11 14 55 AM" src="https://user-images.githubusercontent.com/52669884/118291758-f05a8600-b4a5-11eb-90ac-64a4ee6348b2.png">
<img width="1125" alt="Screen Shot 2021-05-14 at 11 15 03 AM" src="https://user-images.githubusercontent.com/52669884/118291767-f3ee0d00-b4a5-11eb-8eb5-8726d8230b88.png">

[Downloadable html report (must be zipped for github upload) ](https://github.com/transcom/milmove_load_testing/files/6479649/report_1621002704.280355.html.zip)

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7254) for this change.
