### PR TITLE
Add option to use ASDF in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ endif
 ifndef USE_ASDF
 		USE_ASDF:=false
 endif
-
+ifndef PYTHON
+    PYTHON = python
+endif
 ifeq ($(USE_ASDF),true)
 	VENV_DIR = $(PWD)/$(VENV_NAME)
 else

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,6 @@ ifndef USE_ASDF
 		USE_ASDF:=false
 endif
 
-# ASDF versions
-# global $HOME/.tool-versions
-# local $PWD/.tool-versions
-# $(HOME)/.asdf/installs/python/$(PY_VERSION)
-# PYENV versions
-# $(HOME)/.pyenv/versions/$(PY_VERSION)
 ifeq ($(USE_ASDF),true)
 	VENV_DIR = $(PWD)/$(VENV_NAME)
 else

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,21 @@ endif
 ifndef VENV_NAME
 	VENV_NAME = locust-venv
 endif
-VENV_DIR = $(HOME)/.pyenv/versions/$(PY_VERSION)/envs/$(VENV_NAME)
+ifndef USE_ASDF
+		USE_ASDF:=false
+endif
+
+# ASDF versions
+# global $HOME/.tool-versions
+# local $PWD/.tool-versions
+# $(HOME)/.asdf/installs/python/$(PY_VERSION)
+# PYENV versions
+# $(HOME)/.pyenv/versions/$(PY_VERSION)
+ifeq ($(USE_ASDF),true)
+	VENV_DIR = $(PWD)/$(VENV_NAME)
+else
+	VENV_DIR = $(HOME)/.pyenv/versions/$(PY_VERSION)/envs/$(VENV_NAME)
+endif
 
 ifeq ($(VIRTUAL_ENV),$(VENV_DIR))
 	IN_VENV:=true
@@ -21,12 +35,23 @@ help:  ## Print the help documentation
 
 .PHONY: venv
 venv:  ## Setup the local python version and the virtualenv
-	pyenv versions | grep -q "$(PY_VERSION)" || pyenv install -v $(PY_VERSION)
+ifeq ($(USE_ASDF),true)
+	asdf list $(PYTHON) | grep -q $(PY_VERSION) || asdf install $(PYTHON) $(PY_VERSION)
+	asdf local $(PYTHON) $(PY_VERSION)
+	asdf current $(PYTHON)
+	$(PYTHON) -m venv $(VENV_NAME) || echo "Using existing $(VENV_NAME)..."
+else
+	pyenv versions | grep -q $(PY_VERSION) || pyenv install -v $(PY_VERSION)
 	pyenv local $(PY_VERSION)
 	pyenv virtualenv $(PY_VERSION) $(VENV_NAME) || echo "Using existing $(VENV_NAME)..."
+endif
 ifndef IN_VENV
-	@echo "Activate your virtualenv using the following commands:\n\n  pyenv activate $(VENV_NAME)\n\n" \
-	"Alternatively, set the virtualenv to auto-activate with:\n\n  pyenv local $(VENV_NAME)"
+ifeq ($(USE_ASDF),true)
+	@echo "\n>> Activate your virtualenv using the following commands:\n\n source $(VENV_NAME)/bin/activate\n\n"
+else
+	@echo "\n>> Activate your virtualenv using the following commands:\n\n  pyenv activate $(VENV_NAME)\n\n" \
+ "Alternatively, set the virtualenv to auto-activate with:\n\n  pyenv local $(VENV_NAME)"
+endif
 endif
 
 # This target checks that we're in an activated virtualenv for the sake of the following requirements installation:
@@ -34,6 +59,9 @@ endif
 ensure_venv:  ## Ensure that the virtualenv is activated
 ifeq ($(IN_VENV),true)
 	@echo "$(VENV_NAME) has been activated."
+else ifeq ($(USE_ASDF),true)
+	@echo "To proceed, activate your virtualenv using the following command:\n\n  source $(VENV_NAME)/bin/activate\n\n"
+	false
 else
 	@echo "To proceed, activate your virtualenv using the following command:\n\n  pyenv activate $(VENV_NAME)\n"
 	false
@@ -74,8 +102,11 @@ clean:  ## Clean all generated files
 
 .PHONY: teardown
 teardown:  ## Uninstall the virtualenv and remove all files
+ifeq ($(USE_ASDF),true)
+	@echo "To deactivate  and remove your virtualenv using the following command:\n\n  deactivate; rm -fr $(VENV_NAME)\n\n"
+else
 	-pyenv uninstall $(VENV_NAME)
-
+endif
 .PHONY: pretty
 pretty: ensure_venv  ## Prettify the code
 	black .

--- a/README.md
+++ b/README.md
@@ -257,12 +257,15 @@ asdf plugin add python
 
 Create a new python `venv` and run setup
 
-*Note*: Make sure you added `USE_ASDF` to your `.envrc.local`
-
 ```shell script
 make venv
 make setup
 ```
+
+*Notes*:
+
+* Make sure you added `USE_ASDF` to your `.envrc.local`
+* If install for python fails, you can change the version using `PY_VERSION`. (At least one person had an issue with `3.8.5`, `3.9.5` seems to work better on install at the time.)
 
 Teardown python venv
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ This project uses [pyenv](https://github.com/pyenv/pyenv) to manage Python versi
 to contribute without having to spend hours navigating the spiderweb that is Python versions on MacOS (which most of us
 are using).
 
+Alternatives to `pyenv`:
+
+* run using `ASDF`, included below
+* run with Docker, included below
+
 To ensure that you have all the dependencies for `pyenv` installed, first run:
 
 ```shell script
@@ -219,6 +224,53 @@ make teardown
 ```
 
 Remember to recreate your virtual environment with `make venv` before attempting to continue development on the project.
+
+### Alternative Setup: ASDF
+
+It is possible to run with `ASDF` instead of using `pyenv`. The `Makefile` file has been updated to check for the env variable
+`USE_ASDR=true`.
+
+Add `USE_ASDF` to your `.envrc.local` file.
+
+```shell script
+export USE_ASDR=true
+```
+
+Update env locally
+
+```shell script
+direnv allow
+```
+
+Install the prereqs
+
+```shell script
+brew install openssl readline sqlite3 xz zlib
+```
+
+Add python to `ASDF` versioning
+
+```shell script
+asdf plugin add python
+```
+
+Create a new python `venv` and run setup
+
+*Note*: Make sure you added `USE_ASDF` to your `.envrc.local`
+
+```shell script
+make venv
+make setup
+```
+
+Teardown python venv
+
+After you are finished and you would like to remove the `venv`, run the teardown command. This command simply prints
+out the necessary python commands to run to deactivate your env and remove the contents of the `venv`.
+
+```shell script
+make teardown
+```
 
 ### Alternative Setup: Docker
 

--- a/README.md
+++ b/README.md
@@ -229,12 +229,12 @@ Remember to recreate your virtual environment with `make venv` before attempting
 ### Alternative Setup: ASDF
 
 It is possible to run with `ASDF` instead of using `pyenv`. The `Makefile` file has been updated to check for the env variable
-`USE_ASDR=true`.
+`USE_ASDF=true`.
 
 Add `USE_ASDF` to your `.envrc.local` file.
 
 ```shell script
-export USE_ASDR=true
+export USE_ASDF=true
 ```
 
 Update `env` locally

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Add `USE_ASDF` to your `.envrc.local` file.
 export USE_ASDR=true
 ```
 
-Update env locally
+Update `env` locally
 
 ```shell script
 direnv allow
@@ -267,7 +267,7 @@ make setup
 * Make sure you added `USE_ASDF` to your `.envrc.local`
 * If install for python fails, you can change the version using `PY_VERSION`. (At least one person had an issue with `3.8.5`, `3.9.5` seems to work better on install at the time.)
 
-Teardown python venv
+Teardown python `venv`
 
 After you are finished and you would like to remove the `venv`, run the teardown command. This command simply prints
 out the necessary python commands to run to deactivate your env and remove the contents of the `venv`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ in the [LICENSE.txt](./LICENSE.txt) file in this repository.
          * [Setup: pre-commit](#setup-pre-commit)
          * [Setup: pyenv](#setup-pyenv)
          * [Setup: virtualenv](#setup-virtualenv)
+         * [Alternative Setup: ASDF](#alternative-setup-asdf)
          * [Alternative Setup: Docker](#alternative-setup-docker)
          * [Troubleshooting](#troubleshooting)
          * [Testing](#testing)
@@ -129,8 +130,8 @@ are using).
 
 Alternatives to `pyenv`:
 
-* run using `ASDF`, included below
-* run with Docker, included below
+* run using [`ASDF`](#alternative-setup-asdf)
+* run with [Docker](#alternative-setup-docker)
 
 To ensure that you have all the dependencies for `pyenv` installed, first run:
 


### PR DESCRIPTION
## Description

MilMove devs are already using ASDF. This adds the the option to continue using ASDF instead of pyenv.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Command to get the Customer app running for load testing:

Startup milmove server:
```sh
make server_run
```

Follow the README to setup you env. To use ASDF you can do the following:

Note: python 3.8.3 failed to install on my machine so I actually used latest which was 3.9.5. To bypass using 3.8.3 in the Makefile you can manually install python instead of letting the Makefile do it. Try out the Makefile first and if it fails then move on to do it manually and then run the Makefile again. 

```sh
brew install openssl readline sqlite3 xz zlib
asdf plugin add python
USE_ASDF=true make  venv
# follow directions and activate your env
USE_ASDF=true make  setup
```

### Manually installing python with ASDF

```sh
asdf install python latest
asdf local python 3.9.5 
USE_ASDF=true PY_VERSION=3.9.5 make  venv
# follow directions and activate your env
USE_ASDF=true make  setup
```

Running the master repo and NOT this branch. You can run the following just to see the app open up.
```sh
make load_test_milmove
```


## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8058) for this change.

