### PR TITLE
MB-7939 test create_mto_shipments endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,32 +405,7 @@ Ex:
 locust -f locustfiles/prime.py --host local
 ```
 
-To run the test without the web interface, add the `--headless` tag and some guidelines for the test (such as number of
-users, their hatch rate, and the time limit for the test):
-
-```sh
-locust -f locustfiles/prime.py --headless --host local --users 50 --hatch-rate 5 --run-time 60s
-```
-
-To control which tasks run during the test, you can filter using tags:
-
-```sh
-locust -f locustfiles/prime.py --tags prime --exclude-tags support
-```
-
-To specify which `User` classes are spawned from locustfile, add the class name to the end of the command:
-
-```sh
-locust -f locustfiles/prime.py PrimeUser
-```
-
-For more CLI config options, refer to the Locust docs for [Configuration](https://docs.locust.io/en/stable/configuration.html).
-
-To deactivate your virtual environment once you have completed testing, enter:
-
-```sh
-pyenv deactivate
-```
+For mor information on running custom tests, refer to the [wiki](https://github.com/transcom/milmove_load_testing/wiki/Running-Load-Tests-Against-MyMove)
 
 ### Running Tests for Reporting
 

--- a/locustfiles/prime_workflow.py
+++ b/locustfiles/prime_workflow.py
@@ -4,6 +4,7 @@ from locust import HttpUser, between
 from utils.hosts import MilMoveHostMixin, MilMoveDomain
 from utils.constants import PRIME_API_KEY, SUPPORT_API_KEY
 from tasks import PrimeWorkflowTasks
+from tasks.prime_endpoint_workflows import PrimeEndpointWorkflowsTasks
 from utils.parsers import SupportAPIParser, PrimeAPIParser
 
 support_api = SupportAPIParser()
@@ -24,5 +25,5 @@ class PrimeWorkflowUser(MilMoveHostMixin, HttpUser):
     parser = {PRIME_API_KEY: prime_api, SUPPORT_API_KEY: support_api}
 
     # For the tasks, we can define all the workflow tasksets we have set up:
-    tasks = {PrimeWorkflowTasks: 1}
+    tasks = {PrimeWorkflowTasks: 1, PrimeEndpointWorkflowsTasks: 1}
     weight = 1

--- a/locustfiles/prime_workflow.py
+++ b/locustfiles/prime_workflow.py
@@ -3,7 +3,7 @@ from locust import HttpUser, between
 
 from utils.hosts import MilMoveHostMixin, MilMoveDomain
 from utils.constants import PRIME_API_KEY, SUPPORT_API_KEY
-from tasks import PrimeWorkflowTasks
+from tasks.prime_hhg_workflow import PrimeWorkflowTasks
 from tasks.prime_endpoint_workflows import PrimeEndpointWorkflowsTasks
 from utils.parsers import SupportAPIParser, PrimeAPIParser
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -2,7 +2,8 @@
 from .office import ServicesCounselorTasks, TOOTasks  # noqa
 from .milmove import MilMoveTasks  # noqa
 from .prime import PrimeTasks, SupportTasks  # noqa
-from .prime_workflow import PrimeWorkflowTasks  # noqa
+from .prime_hhg_workflow import PrimeWorkflowTasks  # noqa
+from .prime_endpoint_workflows import PrimeEndpointWorkflowsTasks  # noqa
 import warnings
 import requests
 

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -266,7 +266,6 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
     def create_mto_shipment(self, overrides=None):
         # If moveTaskOrderID was provided, get that specific one. Else get any stored one.
         object_id = overrides.get("moveTaskOrderID") if overrides else None
-        mto_shipment = self.get_stored(MTO_SHIPMENT, object_id)
 
         move_task_order = self.get_stored(MOVE_TASK_ORDER, object_id)
         if not move_task_order:

--- a/tasks/prime_endpoint_workflows.py
+++ b/tasks/prime_endpoint_workflows.py
@@ -9,7 +9,7 @@ from utils.constants import MOVE_TASK_ORDER
 logger = logging.getLogger(__name__)
 
 
-@tag("workflow")
+@tag("endpointWorkflow")
 class PrimeEndpointWorkflowsTasks(PrimeTasks, SupportTasks):
     """Workflow Task Set
     Each task is a workflow from start to finish.
@@ -35,15 +35,15 @@ class PrimeEndpointWorkflowsTasks(PrimeTasks, SupportTasks):
 
         # Set shipment type to HHG, so there can be multiple shipments on the same move
         overrides = {"shipmentType": "HHG"}
-        shipment = super().create_mto_shipment(overrides)
+        shipment = self.create_mto_shipment(overrides)
         logger.info(f"{self.workflow_title} - Created shipment {shipment['id'][:8]}")
 
     def _get_move(self):
-        move_task_order = super().get_stored(MOVE_TASK_ORDER)
+        move_task_order = self.get_stored(MOVE_TASK_ORDER)
         if not move_task_order:
             if not self.has_all_default_mto_ids():
-                super().fetch_mto_updates()
-            move_task_order = super().create_move_task_order()
+                self.fetch_mto_updates()
+            move_task_order = self.create_move_task_order()
         if not move_task_order:
             logger.debug(f"{self.workflow_title} ⚠️ No move_task_order returned or created")
             return None

--- a/tasks/prime_endpoint_workflows.py
+++ b/tasks/prime_endpoint_workflows.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from locust import tag, task
+
+from .prime import PrimeTasks, SupportTasks
+from utils.constants import MOVE_TASK_ORDER
+
+logger = logging.getLogger(__name__)
+
+
+@tag("endpointWorkflows")
+class PrimeEndpointWorkflowsTasks(PrimeTasks, SupportTasks):
+    """Workflow Task Set
+    Each task is a workflow from start to finish. Each workflow acts on only one MTO from start to finish.
+    There are multiple workflows for different scenarios such as a single shipment HHG move, or an HHG move with a SIT.
+    Multiple instances of the tasks will run during load testing and will interleave their hits to the server.
+    However they will run in sequence and should all complete without any errors.
+    """
+
+    # workflow_title is a descriptor that can be used in logging anywhere in the workflow
+    workflow_title = None
+
+    # WORKFLOWS
+    @tag("createMTOShipmentWorkflow")
+    @task
+    def create_mto_shipment_workflow(self):
+        """
+        This is a basic workflow that checks if there is an existing move, then calls the create_mto_shipment endpoint.
+        """
+        self.workflow_title = "create_mto_shipment endpoint"
+
+        # Ensure there is a move avaliable for a shipment
+        if not self._get_move():
+            return
+
+        # Set shipment type to HHG, so there can be multiple shipments on the same move
+        overrides = {"shipmentType": "HHG"}
+        shipment = super().create_mto_shipment(overrides)
+        logger.info(f"{self.workflow_title} - Created shipment {shipment['id'][:8]}")
+
+    def _get_move(self):
+        move_task_order = super().get_stored(MOVE_TASK_ORDER)
+        if not move_task_order:
+            if not self.has_all_default_mto_ids():
+                super().fetch_mto_updates()
+            move_task_order = super().create_move_task_order()
+        if not move_task_order:
+            logger.debug(f"{self.workflow_title} ⚠️ No move_task_order returned or created")
+            return None
+        return move_task_order

--- a/tasks/prime_endpoint_workflows.py
+++ b/tasks/prime_endpoint_workflows.py
@@ -9,11 +9,10 @@ from utils.constants import MOVE_TASK_ORDER
 logger = logging.getLogger(__name__)
 
 
-@tag("endpointWorkflows")
+@tag("workflow")
 class PrimeEndpointWorkflowsTasks(PrimeTasks, SupportTasks):
     """Workflow Task Set
-    Each task is a workflow from start to finish. Each workflow acts on only one MTO from start to finish.
-    There are multiple workflows for different scenarios such as a single shipment HHG move, or an HHG move with a SIT.
+    Each task is a workflow from start to finish.
     Multiple instances of the tasks will run during load testing and will interleave their hits to the server.
     However they will run in sequence and should all complete without any errors.
     """

--- a/tasks/prime_hhg_workflow.py
+++ b/tasks/prime_hhg_workflow.py
@@ -31,13 +31,13 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
     # workflow_title is a descriptor that can be used in logging anywhere in the workflow
     workflow_title = None
 
-    # def on_start(self):
-    #     """
-    #     Runs on instantiation of each taskset.
-    #     We need to set up this task set with the list of tasks/workflows we want to run. If we don't define this, all
-    #     the tasks in PrimeTasks and SupportTasks will all be run independently and will likely have errors.
-    #     """
-    #     self.tasks = [self.hhg_move, self.fetch_mto_updates]
+    def on_start(self):
+        """
+        Runs on instantiation of each taskset.
+        We need to set up this task set with the list of tasks/workflows we want to run. If we don't define this, all
+        the tasks in PrimeTasks and SupportTasks will all be run independently and will likely have errors.
+        """
+        self.tasks = [self.hhg_move, self.fetch_mto_updates]
 
     # WORKFLOWS
     @tag("hhgMove")

--- a/tasks/prime_workflow.py
+++ b/tasks/prime_workflow.py
@@ -31,13 +31,13 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
     # workflow_title is a descriptor that can be used in logging anywhere in the workflow
     workflow_title = None
 
-    def on_start(self):
-        """
-        Runs on instantiation of each taskset.
-        We need to set up this task set with the list of tasks/workflows we want to run. If we don't define this, all
-        the tasks in PrimeTasks and SupportTasks will all be run independently and will likely have errors.
-        """
-        self.tasks = [self.hhg_move, self.fetch_mto_updates]
+    # def on_start(self):
+    #     """
+    #     Runs on instantiation of each taskset.
+    #     We need to set up this task set with the list of tasks/workflows we want to run. If we don't define this, all
+    #     the tasks in PrimeTasks and SupportTasks will all be run independently and will likely have errors.
+    #     """
+    #     self.tasks = [self.hhg_move, self.fetch_mto_updates]
 
     # WORKFLOWS
     @tag("hhgMove")


### PR DESCRIPTION
## Description

This PR adds a new file `prime_endpoint_workflows.py`. The intent of this file is to create workflows that will specifically target a single endpoint. To test the primeapi create_mto_shipment endpoint, run the following command:
 
`locust -f locustfiles/prime_workflow --tags createMTOShipmentWorkflow`

I also created added the first two pages to this repo's wiki 🎉 and updated the readme to point to the wiki for some custom test command information.

https://github.com/transcom/milmove_load_testing/wiki

## Reviewer Notes

The naming of the files is a little wonky. Do you have any better suggestions?

## Setup

To load test the create_mto_shipment endpoint complete the following steps:
1. `make server_run` in the mymove repo
2. `locust -f locustfiles/prime_workflow --tags createMTOShipmentWorkflow` in the load testing repo
3. Enter a set number of users and spawn rate (It's easy to test with 10 and 10)

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change.
* [This article](tbd) explains more about the approach used.
