### PR TITLE
Use listMoves endpoint instead of fetchMTOUpdates

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -215,15 +215,15 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
     tags where appropriate to make filtering for custom tests easier.
     """
 
-    @tag(MOVE_TASK_ORDER, "fetchMTOUpdates")
+    @tag(MOVE_TASK_ORDER, "listMoves")
     @task
-    def fetch_mto_updates(self):
+    def list_moves(self):
         timeout = {}
         if self.user.is_local:
             timeout["timeout"] = 15  # set a timeout of 15sec if we're running locally - just for this endpoint
 
-        resp = self.client.get(prime_path("/move-task-orders"), **self.cert_kwargs, **timeout)
-        moves, success = check_response(resp, "fetchMTOUpdates")
+        resp = self.client.get(prime_path("/moves"), **self.cert_kwargs, **timeout)
+        moves, success = check_response(resp, "listMoves")
 
         # Use these MTOs to set the ID values we'll need to create more MTOs
         # (NOTE: we don't care about a failure here because we can set the default IDs instead,

--- a/tasks/prime_endpoint_workflows.py
+++ b/tasks/prime_endpoint_workflows.py
@@ -42,7 +42,7 @@ class PrimeEndpointWorkflowsTasks(PrimeTasks, SupportTasks):
         move_task_order = self.get_stored(MOVE_TASK_ORDER)
         if not move_task_order:
             if not self.has_all_default_mto_ids():
-                self.fetch_mto_updates()
+                self.list_moves()
             move_task_order = self.create_move_task_order()
         if not move_task_order:
             logger.debug(f"{self.workflow_title} ⚠️ No move_task_order returned or created")

--- a/tasks/prime_hhg_workflow.py
+++ b/tasks/prime_hhg_workflow.py
@@ -37,7 +37,7 @@ class PrimeWorkflowTasks(PrimeTasks, SupportTasks):
         We need to set up this task set with the list of tasks/workflows we want to run. If we don't define this, all
         the tasks in PrimeTasks and SupportTasks will all be run independently and will likely have errors.
         """
-        self.tasks = [self.hhg_move, self.fetch_mto_updates]
+        self.tasks = [self.hhg_move, self.list_moves]
 
     # WORKFLOWS
     @tag("hhgMove")


### PR DESCRIPTION
## Description

Removes all references to `fetchMTOUpdates` and leverages the `listMoves` endpoint instead. Note that there are a number of _other_ issues with the Prime workflow at the moment that might be related to input. This PR doesn't address those.

To run the Prime workflow, first run your server in `mymove`:

```sh
make server_run
```

Then, in `milmove_load_testing`, use the `prime_workflow.py` locust file:

```sh
make load_test_prime_workflow
```