### PR TITLE
MB-9667 PR for enabling load test against the dp3/load test environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -25,22 +25,6 @@ export CHAMBER_USE_PATHS=1
 # Sets the number of retries for chamber to 20.
 export CHAMBER_RETRIES=20
 
-# Loads secrets from chamber instead of requiring them to be listed in .envrc.local
-if [ -e .envrc.chamber ]; then
-  # Loading secrets from Chamber can take a while. Prevent direnv from complaining
-  export DIRENV_WARN_TIMEOUT="20s"
-
-  # Evaluate if the files have drifted
-  if ! cmp .envrc.chamber .envrc.chamber.template >/dev/null 2>&1; then
-    log_error "Your .envrc.chamber has drifted from .envrc.chamber.template.
-    Please 'cp .envrc.chamber.template .envrc.chamber' or 'ln -s .envrc.chamber.template .envrc.chamber"
-  fi
-
-  source_env .envrc.chamber
-else
-  log_status "Want to load secrets from chamber? 'ln -s .envrc.chamber.template .envrc.chamber'"
-fi
-
 #### Nix Experiment Start ####
 # if nix is installed, use it
 if [ ! -r .nix-disable  ] && has nix-env; then
@@ -66,6 +50,23 @@ if [ ! -r .nix-disable  ] && has nix-env; then
   # layout after setting PATH so we get the right python version
   layout python3
 fi
+
+# Loads secrets from chamber instead of requiring them to be listed in .envrc.local
+if [ -e .envrc.chamber ]; then
+  # Loading secrets from Chamber can take a while. Prevent direnv from complaining
+  export DIRENV_WARN_TIMEOUT="20s"
+
+  # Evaluate if the files have drifted
+  if ! cmp .envrc.chamber .envrc.chamber.template >/dev/null 2>&1; then
+    log_error "Your .envrc.chamber has drifted from .envrc.chamber.template.
+    Please 'cp .envrc.chamber.template .envrc.chamber' or 'ln -s .envrc.chamber.template .envrc.chamber"
+  fi
+
+  source_env .envrc.chamber
+else
+  log_status "Want to load secrets from chamber? 'ln -s .envrc.chamber.template .envrc.chamber'"
+fi
+
 # ----------------
 # LOCUST REPORTING
 # ----------------

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -32,10 +32,10 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "pre-commit-2.13.0";
+      name = "pre-commit-2.15.0";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "f62847d5655a6954fc946e5d9c81424171cc281e";
+      rev = "8112bb92f9df718eaa077ec77109eecc60240a72";
     }) {}).pre-commit
 
     (import (builtins.fetchGit {
@@ -54,5 +54,12 @@ in buildEnv {
       rev = "14b0f20fa1f56438b74100513c9b1f7c072cf789";
     }) {}).awscli2
 
+    (import (builtins.fetchGit {
+      # Descriptive name to make the store path easier to identify
+      name = "chamber-2.10.2";
+      url = "https://github.com/NixOS/nixpkgs/";
+      ref = "refs/heads/nixpkgs-unstable";
+      rev = "725ef07e543a6f60b534036c684d44e57bb8d5de";
+    }) {}).chamber
 ];
 }

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -16,6 +16,7 @@ class MilMoveEnv(ValueEnum):
     LOCAL = "local"
     EXP = "exp"
     DOD = "dod"
+    DP3 = "dp3"
 
 
 class MilMoveDomain(ValueEnum):
@@ -35,7 +36,7 @@ class MilMoveDomain(ValueEnum):
         return self.value
 
     def host_name(self, env, is_api=False, port="0000", protocol="https"):
-        
+
         """
         Returns the host name for this domain based on the environment, whether or not it is in the API domain, and the
         port and protocol (for local envs).
@@ -58,8 +59,10 @@ class MilMoveDomain(ValueEnum):
 
             return f"{protocol}://{self.local_value}:{port}"
 
+        # allow us to point to another domain if we need to
+        base_domain = os.getenv("BASE_DOMAIN", "loadtest.dp3.us")
         # NOTE: deployed protocol is always https
-        return f"https://{'api' if is_api else self.deployed_value}.loadtest.move.mil"
+        return f"https://{'api' if is_api else self.deployed_value}.{base_domain}"
 
 
 class MilMoveHostMixin:
@@ -162,8 +165,14 @@ class MilMoveHostMixin:
         # We now know we're in a deployed environment, so let's make a deployed cert/key file:
         cert_key = cls.create_deployed_cert_file()
 
+        verify_path = DOD_CA_BUNDLE
+        # DP3 certs are issued by CAs that are well known and so we
+        # don't need any special verification
+        if cls.env == MilMoveEnv.DP3:
+            verify_path = None
+
         # We also need to use the DoD's specific CA bundle for SSL verification in deployed envs:
-        cls.cert_kwargs = {"cert": cert_key, "verify": DOD_CA_BUNDLE}
+        cls.cert_kwargs = {"cert": cert_key, "verify": verify_path}
 
     @classmethod
     def create_deployed_cert_file(cls) -> Optional[str]:
@@ -177,8 +186,8 @@ class MilMoveHostMixin:
         if cls.env == MilMoveEnv.LOCAL:
             return  # can't complete this logic with local certs
 
-        deployed_tls_cert = os.getenv(f"MOVE_MIL_{cls.env.value.upper()}_TLS_CERT")
-        deployed_tls_key = os.getenv(f"MOVE_MIL_{cls.env.value.upper()}_TLS_KEY")
+        deployed_tls_cert = os.environ.get(f"MOVE_MIL_{cls.env.value.upper()}_TLS_CERT")
+        deployed_tls_key = os.environ.get(f"MOVE_MIL_{cls.env.value.upper()}_TLS_KEY")
 
         if not (deployed_tls_cert and deployed_tls_key):
             logger.debug(f"Unable to find cert and key values for environment: {cls.env.value}")

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 class MilMoveEnv(ValueEnum):
     LOCAL = "local"
     EXP = "exp"
+    DOD = "dod"
 
 
 class MilMoveDomain(ValueEnum):
@@ -34,6 +35,7 @@ class MilMoveDomain(ValueEnum):
         return self.value
 
     def host_name(self, env, is_api=False, port="0000", protocol="https"):
+        
         """
         Returns the host name for this domain based on the environment, whether or not it is in the API domain, and the
         port and protocol (for local envs).
@@ -57,7 +59,7 @@ class MilMoveDomain(ValueEnum):
             return f"{protocol}://{self.local_value}:{port}"
 
         # NOTE: deployed protocol is always https
-        return f"https://{'api' if is_api else self.deployed_value}.{env}.move.mil"
+        return f"https://{'api' if is_api else self.deployed_value}.loadtest.move.mil"
 
 
 class MilMoveHostMixin:


### PR DESCRIPTION
## Description

This PR includes Drew's PR to enable locust testing against the dp3/load test environment https://github.com/transcom/milmove_load_testing/pull/80

## Reviewer Notes

See Drew's PR for review notes and set up steps

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
locust -f locustfiles/prime.py --host dp3
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change.
* [This article](tbd) explains more about the approach used.
