### PR TITLE
[MB-9782] Update dockerfile and codebuild script to override locustfile command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM python:3.9.6
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
 
+ARG locustfile
+ENV LOCUSTFILE=$locustfile
+
+RUN echo $LOCUSTFILE
+
 WORKDIR /app
 
 # Copy over and install requirements:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ constants are located here.
 
 This folder is for static files (certificates, PDFs, etc.) that will be used during load testing.
 
+### `ecs`
+
+This directory contains a representation of the task definition for running the docker container in AWS.  To make changes
+to the task definition will require changing the terraform in
+`transcom/transcom-infrasec-gov-nonato/transcom-gov-dev/app-dev/loadtesting.tf`.  This file is updated manually to
+reflect the current state.
+
+### `scripts`
+
+`aws-session-port-forward.py` - This is the script used to access the deployed locust load testing container and forward
+to your local port 4000 accessible at [http://localhost:4000](http://localhost:4000).
+
+`codebuild` - This script is invoked when making a new build/deployment using the AWS CodeBuild service.  It builds a
+new docker image and publishes it to ECR so the service can pull down the new image.  It also controls updating the
+service if there is a new task definition from updating the Terraform code.
+
 ## Getting Started
 
 *Note: These instructions include the relevant commands for MacOS only. Please keep this in mind and be prepared to

--- a/ecs/milmove_load_testing_ecs.json.tmpl
+++ b/ecs/milmove_load_testing_ecs.json.tmpl
@@ -3,7 +3,7 @@
     {
       "command": [
         "-f",
-        "/app/locustfiles/prime.py",
+        "${LOCUSTFILE}",
         "--host",
         "exp",
         "--web-port",
@@ -39,6 +39,10 @@
         {
           "name": "STATIC_TLS_FILE_PATH",
           "value": "/tmp"
+        },
+        {
+          "name": "LOCUSTFILE",
+          "value": "/app/locustfiles/prime.py"
         }
       ],
       "secrets": [

--- a/ecs/milmove_load_testing_ecs.json.tmpl
+++ b/ecs/milmove_load_testing_ecs.json.tmpl
@@ -39,10 +39,6 @@
         {
           "name": "STATIC_TLS_FILE_PATH",
           "value": "/tmp"
-        },
-        {
-          "name": "LOCUSTFILE",
-          "value": "/app/locustfiles/prime.py"
         }
       ],
       "secrets": [

--- a/ecs/milmove_load_testing_ecs.json.tmpl
+++ b/ecs/milmove_load_testing_ecs.json.tmpl
@@ -2,6 +2,9 @@
   "containerDefinitions": [
     {
       "command": [
+        "sh",
+        "-c",
+        "locust"
         "-f",
         "${LOCUSTFILE}",
         "--host",

--- a/ecs/milmove_load_testing_ecs.json.tmpl
+++ b/ecs/milmove_load_testing_ecs.json.tmpl
@@ -1,16 +1,9 @@
 {
   "containerDefinitions": [
     {
+      "entryPoint": ["sh", "-c"],
       "command": [
-        "sh",
-        "-c",
-        "locust"
-        "-f",
-        "${LOCUSTFILE}",
-        "--host",
-        "exp",
-        "--web-port",
-        "4000"
+        "locust -f ${LOCUSTFILE} --host dp3 --web-port 4000"
       ],
       "essential": true,
       "image": "__ACCOUNTID__.dkr.ecr.__REGION__.amazonaws.com/loadtesting:exp",

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -16,7 +16,7 @@ docker push "${ECR_REPO}:exp"
 aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \
-    --task-definition exp-web-loadtesting:3 \
+    --task-definition exp-web-loadtesting:5 \
     --desired-count 1
 
 exit 0

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -23,8 +23,7 @@ current_task_definition=$(aws ecs describe-services \
 aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \
-    --task-definition exp-web-loadtesting:6 \
-    --desired-count 1 \
-    --force-new-deployment
+    --task-definition "${current_task_definition}" \
+    --desired-count 1
 
 exit 0

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -16,7 +16,7 @@ docker push "${ECR_REPO}:exp"
 aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \
-    --task-definition exp-web-loadtesting:5 \
+    --task-definition exp-web-loadtesting:4 \
     --desired-count 1
 
 exit 0

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -24,6 +24,7 @@ aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \
     --task-definition "${current_task_definition}" \
-    --desired-count 1
+    --desired-count 1 \
+    --force-new-deployment
 
 exit 0

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -6,7 +6,7 @@ set -x
 echo "${DOCKER_PASSWORD}" | \
   docker login --username "${DOCKER_USERNAME}" --password-stdin
 
-docker build -t "${ECR_REPO}:exp" --build-arg locustfile="${LOCUSTFILE}".
+docker build -t "${ECR_REPO}:exp" --build-arg locustfile="${LOCUSTFILE}" .
 
 aws ecr get-login-password --region $AWS_REGION \
   | docker login --username AWS --password-stdin "${ECR_REPO}"

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -24,6 +24,7 @@ aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \
     --task-definition exp-web-loadtesting:6 \
-    --desired-count 1
+    --desired-count 1 \
+    --force-new-deployment
 
 exit 0

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -6,6 +6,7 @@ set -x
 echo "${DOCKER_PASSWORD}" | \
   docker login --username "${DOCKER_USERNAME}" --password-stdin
 
+#LOCUSTFILE can be set in the build overrides of the CodeBuild config
 docker build -t "${ECR_REPO}:exp" --build-arg locustfile="${LOCUSTFILE}" .
 
 aws ecr get-login-password --region $AWS_REGION \
@@ -13,6 +14,8 @@ aws ecr get-login-password --region $AWS_REGION \
 
 docker push "${ECR_REPO}:exp"
 
+#This will return an inactive task definition if a new one has been published
+#In that scenario you can specify the new revision manually in update-service
 current_task_definition=$(aws ecs describe-services \
                               --cluster loadtesting \
                               --service exp-web | \
@@ -20,6 +23,9 @@ current_task_definition=$(aws ecs describe-services \
                             cut -d/ -f 2 | \
                             tr -d '"')
 
+#This has not been replacing the current service so you may need to stop the
+#previous deployment until we can figure out why --force-new-deployment is
+#required for the same task definition revision.
 aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -16,7 +16,7 @@ docker push "${ECR_REPO}:exp"
 aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \
-    --task-definition exp-web-loadtesting:4 \
+    --task-definition exp-web-loadtesting:5 \
     --desired-count 1
 
 exit 0

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -23,7 +23,7 @@ current_task_definition=$(aws ecs describe-services \
 aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \
-    --task-definition "${current_task_definition}" \
+    --task-definition exp-web-loadtesting:5 \
     --desired-count 1
 
 exit 0

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -23,7 +23,7 @@ current_task_definition=$(aws ecs describe-services \
 aws ecs update-service \
     --cluster loadtesting \
     --service exp-web \
-    --task-definition exp-web-loadtesting:5 \
+    --task-definition exp-web-loadtesting:6 \
     --desired-count 1
 
 exit 0

--- a/scripts/codebuild
+++ b/scripts/codebuild
@@ -6,7 +6,7 @@ set -x
 echo "${DOCKER_PASSWORD}" | \
   docker login --username "${DOCKER_USERNAME}" --password-stdin
 
-docker build -t "${ECR_REPO}:exp" .
+docker build -t "${ECR_REPO}:exp" --build-arg locustfile="${LOCUSTFILE}".
 
 aws ecr get-login-password --region $AWS_REGION \
   | docker login --username AWS --password-stdin "${ECR_REPO}"


### PR DESCRIPTION
## Description

This PR adds support to the codebuild script to read the locustfile override env when triggering a new load test build.  We then inject that value to allow the user to run the prime, office, or customer load test scripts on the existing deployed container at port 4000.

The task definition change to support this has to be done in Terraform in another PR https://github.com/transcom/transcom-infrasec-gov-nonato/pull/84

I'll update this with the new task definition number when the infra PR gets merged and creates a new revision.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

1. Login to the AWS console from the transcom-infrasec-gov repo with `make aws_console_transcom_gov_dev`
2. Choose CodeBuild from the list of services
3. Select the milmove_load_testing project
4. Click on the button in the top right to "Start build with overrides"
5. In the Source version input enter this branch name `ds-mb-9782-aws-load-testing-trigger-office-customer-locustfiles`
6. Expand the Environment variables override and edit the last Value for the LOCUSTFILE row.
7. By default it is going to run the `/app/locustfiles/prime.py` locustfile test but you can change it to the office `/app/locustfiles/office.py` or `/app/locustfiles/prime_workflow.py` ...
8. Click Start build
9. Wait for the build to finish with the status Succeeded.
10. Open up your terminal in this repo and branch.
11. Start the aws session forward to access the service at port 400 with `aws-vault exec $AWS_PROFILE -- ./scripts/aws-session-port-forward.py`
12. Open localhost:4000 in your browser to start a new test.
13. The tasks tab should indicate that the load tests run are the ones you specified in your CodeBuild environment value.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9782) for this change.

![Screen Shot 2021-11-09 at 10 55 46 AM (2)](https://user-images.githubusercontent.com/52669884/140962053-4f413065-aff8-48da-97b3-84e890d4a0a8.png)
![Screen Shot 2021-11-09 at 10 56 24 AM (2)](https://user-images.githubusercontent.com/52669884/140962148-7b6d4624-5fe7-426f-a0c7-107aeca62da2.png)
![Screen Shot 2021-11-09 at 11 16 58 AM](https://user-images.githubusercontent.com/52669884/140963430-c602b9bf-8584-4d7d-abfa-e46b2199f30c.png)
![Screen Shot 2021-11-09 at 11 19 22 AM](https://user-images.githubusercontent.com/52669884/140963450-0679dbd6-2e58-4993-9f6b-cbabeefd5a58.png)
![Screen Shot 2021-11-09 at 11 21 01 AM](https://user-images.githubusercontent.com/52669884/140963461-f5cac3f9-fa38-47e4-bbaf-c2f3cc3e9942.png)

