### PR TITLE
MB-10413: Convert to using pipenv to manage dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,12 @@ jobs:
           name: install dependencies
           command: |  # use pipenv to install dependencies
             pipenv sync -d
-      # The tests are not passing right now!!!
-      # - run:
-      #     name: run tests
-      #     command: |
-      #       pipenv run pytest --junit-xml=junit/report.xml
-
+      - run:
+          name: run tests
+          command: |
+            pipenv run pytest --junit-xml=junit/report.xml
+      - store_test_results:
+          path: ~/project/junit/report.xml
       - save_cache:
           key: v1-pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           keys:
             - v1-pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
       - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: v1-pipenv-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: v1-pipenv-{{ checksum "Pipfile.lock" }}
       - run: pre-commit install-hooks
       - run:
           name: Run pre-commit tests
@@ -54,7 +54,7 @@ jobs:
           paths:
             - ~/.cache/pre-commit
       - save_cache:
-          key: v1-pipenv-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: v1-pipenv-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
   primary:
     resource_class: small
     docker:
-      - image: trussworks/circleci-docker-primary:c3a4d876a5681cceef9f927392732c259308d158
+      - image: milmove/circleci-docker:86f3163991b707d1351cc01d2c9cdc2dbaae4e93
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,12 @@ jobs:
       - run:
           name: run tests
           command: |
-            pipenv run pytest --junit-xml=junit/report.xml
+            pipenv run pytest --junit-xml=junit/report.xml --cov-report html:coverage_html --cov=utils --cov=tasks
       - store_test_results:
           path: ~/project/junit/report.xml
+      - store_artifacts:
+          path: ~/project/coverage_html
+          destination: coverage_html
       - save_cache:
           key: v1-pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ executors:
     resource_class: small
     docker:
       - image: milmove/circleci-docker:86f3163991b707d1351cc01d2c9cdc2dbaae4e93
+    environment:
+      PIPENV_VENV_IN_PROJECT: true
 
 jobs:
 
@@ -28,14 +30,30 @@ jobs:
       - restore_cache:
           keys:
             - v1-pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+      - restore_cache:  # ensure this step occurs *before* installing dependencies
+          key: v1-pipenv-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run: pre-commit install-hooks
       - run:
           name: Run pre-commit tests
           command: pre-commit run --all-files
+      - run:
+          name: install dependencies
+          command: |  # use pipenv to install dependencies
+            pipenv sync -d
+      # The tests are not passing right now!!!
+      # - run:
+      #     name: run tests
+      #     command: |
+      #       pipenv run pytest --junit-xml=junit/report.xml
+
       - save_cache:
           key: v1-pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:
             - ~/.cache/pre-commit
+      - save_cache:
+          key: v1-pipenv-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - ".venv"
 
 workflows:
   version: 2

--- a/.envrc
+++ b/.envrc
@@ -47,8 +47,6 @@ if [ ! -r .nix-disable  ] && has nix-env; then
   # is available on the path
   PATH_add ${NIX_PROFILE}/bin
 
-  # layout after setting PATH so we get the right python version
-  layout python3
 fi
 
 # Loads secrets from chamber instead of requiring them to be listed in .envrc.local
@@ -85,3 +83,6 @@ if [ -e .envrc.local ]
 then
   source_env .envrc.local
 fi
+
+# layout after setting PATH so we get the right python version
+layout pipenv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.10b0
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.9
         exclude: >
           (?x)^(
             scripts/gen-docs-index|
@@ -12,7 +12,7 @@ repos:
         args: ['--line-length', '120']
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
+    rev: 4.0.1
     hooks:
       - id: flake8
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,6 @@ repos:
     hooks:
       - id: black
         language_version: python3.9
-        exclude: >
-          (?x)^(
-            scripts/gen-docs-index|
-          )$
-        args: ['--line-length', '120']
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 4.0.1

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-locust-venv

--- a/Brewfile.local
+++ b/Brewfile.local
@@ -4,6 +4,6 @@ brew 'direnv'
 brew 'libev'
 brew 'pre-commit'
 brew 'pyenv'
-brew 'pyenv-virtualenv'
+brew 'pipenv'
 
 cask 'aws-vault'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN pip install pipenv
 # outside of virtualenv
 COPY Pipfile Pipfile.lock /app/
 RUN set -x \
-    && pipenv lock --keep-outdated --requirements | pip install -r /dev/stdin
+    && pipenv install --system --deploy --site-packages \
+    && rm -rf /root/.local/share/virtualenv /root/.local/share/virtualenvs
 
 # Copy over everything else for the app:
 COPY docker.__init__.py /app/__init__.py

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,9 @@ help:  ## Print the help documentation
 install_tools:  ## Install tools needed for project.
 	scripts/install_tools
 
-.PHONY: ensure_venv
-ensure_venv:  ## Ensure that the virtualenv is activated.
-ifndef VIRTUAL_ENV
-	@echo "Virtual env not defined. If you are using nix, make sure it's not disabled. If you aren't using nix, run 'make setup'."
-	false
-endif
-
 .PHONY: install_python_deps
-install_python_deps: ensure_venv ## Install all python dependencies/requirements
-	pip install -r requirements.txt
-	pip install -r requirements-dev.txt
+install_python_deps: ## Install all python dependencies/requirements
+	pipenv install
 
 .PHONY: ensure_pre_commit
 ensure_pre_commit: .git/hooks/pre-commit  ## Ensure pre-commit is installed
@@ -53,11 +45,11 @@ clean:  ## Clean all generated files
 	find ./ -type f -name '*.pyc' -delete
 
 .PHONY: pretty
-pretty: ensure_venv  ## Prettify the code
+pretty: ## Prettify the code
 	black .
 
 .PHONY: lint
-lint: ensure_venv  ## Run linting tests
+lint: ## Run linting tests
 	flake8 .
 
 .PHONY: generate_readme_toc

--- a/Pipfile
+++ b/Pipfile
@@ -15,9 +15,9 @@ black = "==21.10b0"
 flake8 = "*"
 pytest = "*"
 pytest-mock = "*"
-python-language-server = "*"
 cryptography = "*"
 responses = "*"
+python-lsp-server = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,21 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+requests = ">=2.22.0"
+locust = ">=1"
+prance = {version = "==0.19.0", extras = ["cli", "osv"]}
+Faker = "*"
+
+[dev-packages]
+# pipenv doesn't resolve pre-release versions, so manually pin
+black = "==21.10b0"
+flake8 = "*"
+pytest = "*"
+pytest-mock = "*"
+python-language-server = "*"
+
+[requires]
+python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ pytest-mock = "*"
 cryptography = "*"
 responses = "*"
 python-lsp-server = "*"
+pytest-cov = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,8 @@ flake8 = "*"
 pytest = "*"
 pytest-mock = "*"
 python-language-server = "*"
+cryptography = "*"
+responses = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2181b2785aba7ea8897a50a5655bfc9812f6b77d026f56d26ee09abdd0b6f2cd"
+            "sha256": "64f0450461c09a147326e998e7d98d12855d8d12f079bd08361794fce05e20ed"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -527,7 +527,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -645,7 +645,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "text-unidecode": {
@@ -761,12 +761,108 @@
             "index": "pypi",
             "version": "==21.10b0"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "version": "==2021.10.8"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3",
+                "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2",
+                "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636",
+                "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20",
+                "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728",
+                "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27",
+                "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66",
+                "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443",
+                "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0",
+                "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7",
+                "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39",
+                "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605",
+                "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a",
+                "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37",
+                "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029",
+                "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139",
+                "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc",
+                "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df",
+                "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14",
+                "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880",
+                "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2",
+                "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a",
+                "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e",
+                "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474",
+                "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024",
+                "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8",
+                "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0",
+                "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e",
+                "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a",
+                "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e",
+                "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032",
+                "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6",
+                "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e",
+                "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b",
+                "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e",
+                "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954",
+                "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962",
+                "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c",
+                "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4",
+                "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55",
+                "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962",
+                "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023",
+                "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c",
+                "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6",
+                "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8",
+                "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382",
+                "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7",
+                "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc",
+                "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997",
+                "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"
+            ],
+            "version": "==1.15.0"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
+                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.7"
+        },
         "click": {
             "hashes": [
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
             "version": "==7.1.2"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:07bb7fbfb5de0980590ddfc7f13081520def06dc9ed214000ad4372fb4e3c7f6",
+                "sha256:18d90f4711bf63e2fb21e8c8e51ed8189438e6b35a6d996201ebd98a26abbbe6",
+                "sha256:1ed82abf16df40a60942a8c211251ae72858b25b7421ce2497c2eb7a1cee817c",
+                "sha256:22a38e96118a4ce3b97509443feace1d1011d0571fae81fc3ad35f25ba3ea999",
+                "sha256:2d69645f535f4b2c722cfb07a8eab916265545b3475fdb34e0be2f4ee8b0b15e",
+                "sha256:4a2d0e0acc20ede0f06ef7aa58546eee96d2592c00f450c9acb89c5879b61992",
+                "sha256:54b2605e5475944e2213258e0ab8696f4f357a31371e538ef21e8d61c843c28d",
+                "sha256:7075b304cd567694dc692ffc9747f3e9cb393cc4aa4fb7b9f3abd6f5c4e43588",
+                "sha256:7b7ceeff114c31f285528ba8b390d3e9cfa2da17b56f11d366769a807f17cbaa",
+                "sha256:7eba2cebca600a7806b893cb1d541a6e910afa87e97acf2021a22b32da1df52d",
+                "sha256:928185a6d1ccdb816e883f56ebe92e975a262d31cc536429041921f8cb5a62fd",
+                "sha256:9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d",
+                "sha256:a688ebcd08250eab5bb5bca318cc05a8c66de5e4171a65ca51db6bd753ff8953",
+                "sha256:abb5a361d2585bb95012a19ed9b2c8f412c5d723a9836418fab7aaa0243e67d2",
+                "sha256:c10c797ac89c746e488d2ee92bd4abd593615694ee17b2500578b63cad6b93a8",
+                "sha256:ced40344e811d6abba00295ced98c01aecf0c2de39481792d87af4fa58b7b4d6",
+                "sha256:d57e0cdc1b44b6cdf8af1d01807db06886f10177469312fbde8f44ccbb284bc9",
+                "sha256:d99915d6ab265c22873f1b4d6ea5ef462ef797b4140be4c9d8b179915e0985c6",
+                "sha256:eb80e8a1f91e4b7ef8b33041591e6d89b2b8e122d787e87eeb2b08da71bb16ad",
+                "sha256:ebeddd119f526bcf323a89f853afb12e225902a24d29b55fe18dd6fcb2838a76"
+            ],
+            "index": "pypi",
+            "version": "==35.0.0"
         },
         "flake8": {
             "hashes": [
@@ -775,6 +871,14 @@
             ],
             "index": "pypi",
             "version": "==4.0.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.3"
         },
         "iniconfig": {
             "hashes": [
@@ -860,6 +964,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.8.0"
         },
+        "pycparser": {
+            "hashes": [
+                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+            ],
+            "version": "==2.21"
+        },
         "pyflakes": {
             "hashes": [
                 "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
@@ -873,7 +984,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -961,12 +1072,36 @@
             ],
             "version": "==2021.11.10"
         },
+        "requests": {
+            "hashes": [
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+            ],
+            "index": "pypi",
+            "version": "==2.26.0"
+        },
+        "responses": {
+            "hashes": [
+                "sha256:5955ad3468fe8eb5fb736cdab4943457b7768f8670fa3624b4e26ff52dfe20c0",
+                "sha256:866757987d1962aa908d9c8b3185739faefd72a359e95459de0c2e4e5369c9b2"
+            ],
+            "index": "pypi",
+            "version": "==0.15.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "tomli": {
@@ -1032,8 +1167,16 @@
                 "sha256:ff0ae4b1dc70c3362b04f4127e228b17e84946de611f85b32f565b990762deaf",
                 "sha256:fffe509f556861c7343c6cba57ed05fe7bcf4b48a934a5b946ccb45428cf8883"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==4.2.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.7"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "979b7d5bac9412e824531568752200e304d87849a59b7cef8eee4cd8e9ed0241"
+            "sha256": "f1a2e14c40d30df38f52f3181cb9236fcf97eabcd91a85e3b0ef38dfea21a589"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -838,6 +838,62 @@
             ],
             "version": "==7.1.2"
         },
+        "coverage": {
+            "extras": [
+                "toml"
+            ],
+            "hashes": [
+                "sha256:046647b96969fda1ae0605f61288635209dd69dcd27ba3ec0bf5148bc157f954",
+                "sha256:06d009e8a29483cbc0520665bc46035ffe9ae0e7484a49f9782c2a716e37d0a0",
+                "sha256:0cde7d9fe2fb55ff68ebe7fb319ef188e9b88e0a3d1c9c5db7dd829cd93d2193",
+                "sha256:1de9c6f5039ee2b1860b7bad2c7bc3651fbeb9368e4c4d93e98a76358cdcb052",
+                "sha256:24ed38ec86754c4d5a706fbd5b52b057c3df87901a8610d7e5642a08ec07087e",
+                "sha256:27a3df08a855522dfef8b8635f58bab81341b2fb5f447819bc252da3aa4cf44c",
+                "sha256:310c40bed6b626fd1f463e5a83dba19a61c4eb74e1ac0d07d454ebbdf9047e9d",
+                "sha256:3348865798c077c695cae00da0924136bb5cc501f236cfd6b6d9f7a3c94e0ec4",
+                "sha256:35b246ae3a2c042dc8f410c94bcb9754b18179cdb81ff9477a9089dbc9ecc186",
+                "sha256:3f546f48d5d80a90a266769aa613bc0719cb3e9c2ef3529d53f463996dd15a9d",
+                "sha256:586d38dfc7da4a87f5816b203ff06dd7c1bb5b16211ccaa0e9788a8da2b93696",
+                "sha256:5d3855d5d26292539861f5ced2ed042fc2aa33a12f80e487053aed3bcb6ced13",
+                "sha256:610c0ba11da8de3a753dc4b1f71894f9f9debfdde6559599f303286e70aeb0c2",
+                "sha256:62646d98cf0381ffda301a816d6ac6c35fc97aa81b09c4c52d66a15c4bef9d7c",
+                "sha256:66af99c7f7b64d050d37e795baadf515b4561124f25aae6e1baa482438ecc388",
+                "sha256:675adb3b3380967806b3cbb9c5b00ceb29b1c472692100a338730c1d3e59c8b9",
+                "sha256:6e5a8c947a2a89c56655ecbb789458a3a8e3b0cbf4c04250331df8f647b3de59",
+                "sha256:7a39590d1e6acf6a3c435c5d233f72f5d43b585f5be834cff1f21fec4afda225",
+                "sha256:80cb70264e9a1d04b519cdba3cd0dc42847bf8e982a4d55c769b9b0ee7cdce1e",
+                "sha256:82fdcb64bf08aa5db881db061d96db102c77397a570fbc112e21c48a4d9cb31b",
+                "sha256:8492d37acdc07a6eac6489f6c1954026f2260a85a4c2bb1e343fe3d35f5ee21a",
+                "sha256:94f558f8555e79c48c422045f252ef41eb43becdd945e9c775b45ebfc0cbd78f",
+                "sha256:958ac66272ff20e63d818627216e3d7412fdf68a2d25787b89a5c6f1eb7fdd93",
+                "sha256:95a58336aa111af54baa451c33266a8774780242cab3704b7698d5e514840758",
+                "sha256:96129e41405887a53a9cc564f960d7f853cc63d178f3a182fdd302e4cab2745b",
+                "sha256:97ef6e9119bd39d60ef7b9cd5deea2b34869c9f0b9777450a7e3759c1ab09b9b",
+                "sha256:98d44a8136eebbf544ad91fef5bd2b20ef0c9b459c65a833c923d9aa4546b204",
+                "sha256:9d2c2e3ce7b8cc932a2f918186964bd44de8c84e2f9ef72dc616f5bb8be22e71",
+                "sha256:a300b39c3d5905686c75a369d2a66e68fd01472ea42e16b38c948bd02b29e5bd",
+                "sha256:a34fccb45f7b2d890183a263578d60a392a1a218fdc12f5bce1477a6a68d4373",
+                "sha256:a4d48e42e17d3de212f9af44f81ab73b9378a4b2b8413fd708d0d9023f2bbde4",
+                "sha256:af45eea024c0e3a25462fade161afab4f0d9d9e0d5a5d53e86149f74f0a35ecc",
+                "sha256:ba6125d4e55c0b8e913dad27b22722eac7abdcb1f3eab1bd090eee9105660266",
+                "sha256:bc1ee1318f703bc6c971da700d74466e9b86e0c443eb85983fb2a1bd20447263",
+                "sha256:c18725f3cffe96732ef96f3de1939d81215fd6d7d64900dcc4acfe514ea4fcbf",
+                "sha256:c8e9c4bcaaaa932be581b3d8b88b677489975f845f7714efc8cce77568b6711c",
+                "sha256:cc799916b618ec9fd00135e576424165691fec4f70d7dc12cfaef09268a2478c",
+                "sha256:cd2d11a59afa5001ff28073ceca24ae4c506da4355aba30d1e7dd2bd0d2206dc",
+                "sha256:d0a595a781f8e186580ff8e3352dd4953b1944289bec7705377c80c7e36c4d6c",
+                "sha256:d3c5f49ce6af61154060640ad3b3281dbc46e2e0ef2fe78414d7f8a324f0b649",
+                "sha256:d9a635114b88c0ab462e0355472d00a180a5fbfd8511e7f18e4ac32652e7d972",
+                "sha256:e5432d9c329b11c27be45ee5f62cf20a33065d482c8dec1941d6670622a6fb8f",
+                "sha256:eab14fdd410500dae50fd14ccc332e65543e7b39f6fc076fe90603a0e5d2f929",
+                "sha256:ebcc03e1acef4ff44f37f3c61df478d6e469a573aa688e5a162f85d7e4c3860d",
+                "sha256:fae3fe111670e51f1ebbc475823899524e3459ea2db2cb88279bbfb2a0b8a3de",
+                "sha256:fd92ece726055e80d4e3f01fff3b91f54b18c9c357c48fcf6119e87e2461a091",
+                "sha256:ffa545230ca2ad921ad066bf8fd627e7be43716b6e0fcf8e32af1b8188ccb0ab"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.1.2"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:07bb7fbfb5de0980590ddfc7f13081520def06dc9ed214000ad4372fb4e3c7f6",
@@ -994,6 +1050,14 @@
             ],
             "index": "pypi",
             "version": "==6.2.5"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6",
+                "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"
+            ],
+            "index": "pypi",
+            "version": "==3.0.0"
         },
         "pytest-mock": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,1039 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "2181b2785aba7ea8897a50a5655bfc9812f6b77d026f56d26ee09abdd0b6f2cd"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "brotli": {
+            "hashes": [
+                "sha256:160c78292e98d21e73a4cc7f76a234390e516afcd982fa17e1422f7c6a9ce9c8",
+                "sha256:16d528a45c2e1909c2798f27f7bf0a3feec1dc9e50948e738b961618e38b6a7b",
+                "sha256:19598ecddd8a212aedb1ffa15763dd52a388518c4550e615aed88dc3753c0f0c",
+                "sha256:1c48472a6ba3b113452355b9af0a60da5c2ae60477f8feda8346f8fd48e3e87c",
+                "sha256:268fe94547ba25b58ebc724680609c8ee3e5a843202e9a381f6f9c5e8bdb5c70",
+                "sha256:269a5743a393c65db46a7bb982644c67ecba4b8d91b392403ad8a861ba6f495f",
+                "sha256:26d168aac4aaec9a4394221240e8a5436b5634adc3cd1cdf637f6645cecbf181",
+                "sha256:29d1d350178e5225397e28ea1b7aca3648fcbab546d20e7475805437bfb0a130",
+                "sha256:2aad0e0baa04517741c9bb5b07586c642302e5fb3e75319cb62087bd0995ab19",
+                "sha256:35a3edbe18e876e596553c4007a087f8bcfd538f19bc116917b3c7522fca0429",
+                "sha256:3b78a24b5fd13c03ee2b7b86290ed20efdc95da75a3557cc06811764d5ad1126",
+                "sha256:40d15c79f42e0a2c72892bf407979febd9cf91f36f495ffb333d1d04cebb34e4",
+                "sha256:44bb8ff420c1d19d91d79d8c3574b8954288bdff0273bf788954064d260d7ab0",
+                "sha256:4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438",
+                "sha256:503fa6af7da9f4b5780bb7e4cbe0c639b010f12be85d02c99452825dd0feef3f",
+                "sha256:56d027eace784738457437df7331965473f2c0da2c70e1a1f6fdbae5402e0389",
+                "sha256:5913a1177fc36e30fcf6dc868ce23b0453952c78c04c266d3149b3d39e1410d6",
+                "sha256:5b6ef7d9f9c38292df3690fe3e302b5b530999fa90014853dcd0d6902fb59f26",
+                "sha256:5cb1e18167792d7d21e21365d7650b72d5081ed476123ff7b8cac7f45189c0c7",
+                "sha256:61a7ee1f13ab913897dac7da44a73c6d44d48a4adff42a5701e3239791c96e14",
+                "sha256:622a231b08899c864eb87e85f81c75e7b9ce05b001e59bbfbf43d4a71f5f32b2",
+                "sha256:68715970f16b6e92c574c30747c95cf8cf62804569647386ff032195dc89a430",
+                "sha256:6b2ae9f5f67f89aade1fab0f7fd8f2832501311c363a21579d02defa844d9296",
+                "sha256:6c772d6c0a79ac0f414a9f8947cc407e119b8598de7621f39cacadae3cf57d12",
+                "sha256:76ffebb907bec09ff511bb3acc077695e2c32bc2142819491579a695f77ffd4d",
+                "sha256:7cb81373984cc0e4682f31bc3d6be9026006d96eecd07ea49aafb06897746452",
+                "sha256:7ee83d3e3a024a9618e5be64648d6d11c37047ac48adff25f12fa4226cf23d1c",
+                "sha256:854c33dad5ba0fbd6ab69185fec8dab89e13cda6b7d191ba111987df74f38761",
+                "sha256:87fdccbb6bb589095f413b1e05734ba492c962b4a45a13ff3408fa44ffe6479b",
+                "sha256:88c63a1b55f352b02c6ffd24b15ead9fc0e8bf781dbe070213039324922a2eea",
+                "sha256:8a674ac10e0a87b683f4fa2b6fa41090edfd686a6524bd8dedbd6138b309175c",
+                "sha256:93130612b837103e15ac3f9cbacb4613f9e348b58b3aad53721d92e57f96d46a",
+                "sha256:9744a863b489c79a73aba014df554b0e7a0fc44ef3f8a0ef2a52919c7d155031",
+                "sha256:9749a124280a0ada4187a6cfd1ffd35c350fb3af79c706589d98e088c5044267",
+                "sha256:97f715cf371b16ac88b8c19da00029804e20e25f30d80203417255d239f228b5",
+                "sha256:9bf919756d25e4114ace16a8ce91eb340eb57a08e2c6950c3cebcbe3dff2a5e7",
+                "sha256:9d12cf2851759b8de8ca5fde36a59c08210a97ffca0eb94c532ce7b17c6a3d1d",
+                "sha256:a72661af47119a80d82fa583b554095308d6a4c356b2a554fdc2799bc19f2a43",
+                "sha256:afde17ae04d90fbe53afb628f7f2d4ca022797aa093e809de5c3cf276f61bbfa",
+                "sha256:b663f1e02de5d0573610756398e44c130add0eb9a3fc912a09665332942a2efb",
+                "sha256:c2415d9d082152460f2bd4e382a1e85aed233abc92db5a3880da2257dc7daf7b",
+                "sha256:c83aa123d56f2e060644427a882a36b3c12db93727ad7a7b9efd7d7f3e9cc2c4",
+                "sha256:cfc391f4429ee0a9370aa93d812a52e1fee0f37a81861f4fdd1f4fb28e8547c3",
+                "sha256:db844eb158a87ccab83e868a762ea8024ae27337fc7ddcbfcddd157f841fdfe7",
+                "sha256:defed7ea5f218a9f2336301e6fd379f55c655bea65ba2476346340a0ce6f74a1",
+                "sha256:e16eb9541f3dd1a3e92b89005e37b1257b157b7256df0e36bd7b33b50be73bcb",
+                "sha256:f909bbbc433048b499cb9db9e713b5d8d949e8c109a2a548502fb9aa8630f0b1"
+            ],
+            "version": "==1.0.9"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "version": "==2021.10.8"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
+                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.7"
+        },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "version": "==7.1.2"
+        },
+        "configargparse": {
+            "hashes": [
+                "sha256:18f6535a2db9f6e02bd5626cc7455eac3e96b9ab3d969d366f9aafd5c5c00fe7",
+                "sha256:1b0b3cbf664ab59dada57123c81eff3d9737e0d11d8cf79e3d6eb10823f1739f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.5.3"
+        },
+        "faker": {
+            "hashes": [
+                "sha256:b9ea5970f43c1fa05443d1885fbed822aba816facefa053d3d20168bfef4ae84",
+                "sha256:cfe4eed0309cd5325c40817519f8fbb18281a3f43a9a23fe03e3e7f091a9775b"
+            ],
+            "index": "pypi",
+            "version": "==9.8.1"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2",
+                "sha256:cb90f62f1d8e4dc4621f52106613488b5ba826b2e1e10a33eac92f723093ab6a"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.2"
+        },
+        "flask-basicauth": {
+            "hashes": [
+                "sha256:df5ebd489dc0914c224419da059d991eb72988a01cdd4b956d52932ce7d501ff"
+            ],
+            "version": "==0.2.0"
+        },
+        "flask-cors": {
+            "hashes": [
+                "sha256:74efc975af1194fc7891ff5cd85b0f7478be4f7f59fe158102e91abb72bb4438",
+                "sha256:b60839393f3b84a0f3746f6cdca56c1ad7426aa738b70d6c61375857823181de"
+            ],
+            "version": "==3.0.10"
+        },
+        "gevent": {
+            "hashes": [
+                "sha256:02d1e8ca227d0ab0b7917fd7e411f9a534475e0a41fb6f434e9264b20155201a",
+                "sha256:0c7b4763514fec74c9fe6ad10c3de62d8fe7b926d520b1e35eb6887181b954ff",
+                "sha256:1c9c87b15f792af80edc950a83ab8ef4f3ba3889712211c2c42740ddb57b5492",
+                "sha256:23077d87d1589ac141c22923fd76853d2cc5b7e3c5e1f1f9cdf6ff23bc9790fc",
+                "sha256:37a469a99e6000b42dd0b9bbd9d716dbd66cdc6e5738f136f6a266c29b90ee99",
+                "sha256:3b600145dc0c5b39c6f89c2e91ec6c55eb0dd52dc8148228479ca42cded358e4",
+                "sha256:3f5ba654bdd3c774079b553fef535ede5b52c7abd224cb235a15da90ae36251b",
+                "sha256:43e93e1a4738c922a2416baf33f0afb0a20b22d3dba886720bc037cd02a98575",
+                "sha256:473f918bdf7d2096e391f66bd8ce1e969639aa235e710aaf750a37774bb585bd",
+                "sha256:4c94d27be9f0439b28eb8bd0f879e6142918c62092fda7fb96b6d06f01886b94",
+                "sha256:55ede95f41b74e7506fab293ad04cc7fc2b6f662b42281e9f2d668ad3817b574",
+                "sha256:6cad37a55e904879beef2a7e7c57c57d62fde2331fef1bec7f2b2a7ef14da6a2",
+                "sha256:72d4c2a8e65bbc702db76456841c7ddd6de2d9ab544a24aa74ad9c2b6411a269",
+                "sha256:75c29ed5148c916021d39d2fac90ccc0e19adf854626a34eaee012aa6b1fcb67",
+                "sha256:84e1af2dfb4ea9495cb914b00b6303ca0d54bf0a92e688a17e60f6b033873df2",
+                "sha256:8d8655ce581368b7e1ab42c8a3a166c0b43ea04e59970efbade9448864585e99",
+                "sha256:90131877d3ce1a05da1b718631860815b89ff44e93c42d168c9c9e8893b26318",
+                "sha256:9d46bea8644048ceac5737950c08fc89c37a66c34a56a6c9e3648726e60cb767",
+                "sha256:a8656d6e02bf47d7fa47728cf7a7cbf408f77ef1fad12afd9e0e3246c5de1707",
+                "sha256:aaf1451cd0d9c32f65a50e461084a0540be52b8ea05c18669c95b42e1f71592a",
+                "sha256:afc877ff4f277d0e51a1206d748fdab8c1e0256f7a05e1b1067abbed71c64da9",
+                "sha256:b10c3326edb76ec3049646dc5131608d6d3733b5adfc75d34852028ecc67c52c",
+                "sha256:ceec7c5f15fb2f9b767b194daa55246830db6c7c3c2f0b1c7e9e90cb4d01f3f9",
+                "sha256:e00dc0450f79253b7a3a7f2a28e6ca959c8d0d47c0f9fa2c57894c7974d5965f",
+                "sha256:e91632fdcf1c9a33e97e35f96edcbdf0b10e36cf53b58caa946dca4836bb688c",
+                "sha256:f39d5defda9443b5fb99a185050e94782fe7ac38f34f751b491142216ad23bc7"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==21.8.0"
+        },
+        "geventhttpclient": {
+            "hashes": [
+                "sha256:01c9f59dc508a82378ca132e4a6fd1717e869aa590dbc8e7e492986a085a72b8",
+                "sha256:073fa8bef9745b3287979148bc5ca688780198b6bbb04d6fade18a1c54544ccc",
+                "sha256:0b934a7f30f71fca5c3a0a52b258a49d1d0efb9b195a0c0568ebbed891c91d7e",
+                "sha256:182c0c0e5c00d1ebf780ce1710de558afa4cdf043868238c7a22e136359ff103",
+                "sha256:1b0c15e4da83b724c812e76e79eb85f230a194c1fc88d1f4d47ded32b31a84bb",
+                "sha256:2bb160ca3a6d53f9ea9bfd1aa901c5a03d39a6f9a3a802de734a8447ca29df9c",
+                "sha256:31a650e38c9bc9d96b66d574af7cca4206244ab5e2daad6209420c63fbdc2f83",
+                "sha256:32401a3d018e2e71a05a6427cc3b44fa9361678c6d6162c50ebe03e3af974aa0",
+                "sha256:33d414082ff1f8e00a5396c17a6e8876c7f85ca50c08cb61df305a13757d7bd9",
+                "sha256:3c67a1800ba975e8a1c3778c01d53b62e87c50a6a88345a2675d0ccdebf16d61",
+                "sha256:3ca71445decdc90f28f2e43212da51acb6129139bb465324737a5779c9fbada1",
+                "sha256:3d14aac14c46a4c9b1cc938aaefefa1eef4d9eb0b70ac32869354cff085295b6",
+                "sha256:3dbc316d0e9367626f108d86d14b5e882ef9783c381a684682dc849a8e0c2c9f",
+                "sha256:3f975acefdd2e6ed531cc851e9f86bbad0f4216ac1926c4cdb5a8223a20538f4",
+                "sha256:421a17dab9d17d6357250a8689f8a2b9c3d46177b2b04b26a6f19dc8df134c12",
+                "sha256:43dde1d98a194dc27bd9e38df62371d0f5d25a8e5f1dfb09dc1cd2fae5b492fb",
+                "sha256:49a42d0043840436d742fb227fae5135eb3535b740187c55d9cefa13508d15b5",
+                "sha256:4e001608847d06cc0e5c3c0a619c5c5313bb1f9c6e6e4bccd3e78572f8fb9ebb",
+                "sha256:6a32a11a3ee1e475957d15da0fff93d7cf135b54a5ea92307236a6ac2ac0d863",
+                "sha256:6f0c9a31cc52cf2730527875bc06bde65b983c45f14d7692afeebad18456adc9",
+                "sha256:7153bf3ead545cbc220cd032038bb543073496f8c41c18ec021fad47f8eda164",
+                "sha256:7237c2ab19e1952598e1a75c01b69595440728bb570dbe528f9805c89b1d3970",
+                "sha256:727640fca6ede582aacb528ebceacb7b2bf66ab9686fb9900ea7db2c951a747e",
+                "sha256:76069c60cf24719fc1395ed2c1b8b8b2b041080fea2501aca24fa2a3625e6bf6",
+                "sha256:845800cb2f544ca835e764dfbaade57eba35a35a57e3fbc6676932d6f3996b9c",
+                "sha256:8527f715d71d6ac743072f2674d2286517577b712dbda153b0f15c3b0be58d2b",
+                "sha256:86057e189cafa5a28dfb02b05702930fa5767b265103c34dad38721f9100d76c",
+                "sha256:8bc0e28d1cc5d9c10909e4c646f8e652594cadb94fa475af5f3e4d8499ed5bb9",
+                "sha256:943dba14695c6ee2b223453681409d7145a252f4e5728b4084d46cf5a0818bc3",
+                "sha256:9dbb29de564deb0d76464b9fd16c853f19f4210bf9e162f6f38c712e83d1f8cb",
+                "sha256:b0dd0c06f8e22f369b35b5f572b7053c3ee5f0f70843fa2137c387d5c07cca29",
+                "sha256:c2dcb26b92a296dff6c5cc2446b66ac7361ea058b9f0a14dcdf080a5215dc412",
+                "sha256:c4f3e3c7bff985ed157388c33f170f19599235b8019e583670f9d9edb8ba6e67",
+                "sha256:cdc2164ca08f170d996c8862b43787b31950496f9a58da167679c332d231d8ea",
+                "sha256:d241e0ea4a1cc27547021ef7b93e7899734343d25f9b1912599af180336b3289",
+                "sha256:d80ec9ff42b7219f33558185499d0b4365597fc55ff886207b45f5632e099780",
+                "sha256:f0734dae0672a1d6b0bc4117d68c7d043e182583d1437bcdf229dd44f7d038ce",
+                "sha256:f0cb141fdeae74f2e078e06eea456809f289f34c1cfb471dae0b3e0afd01b77b",
+                "sha256:f1562957ddf70691c737c8fc6b44aa6720882a74feae3e0108a985a04139bb41",
+                "sha256:f5cef10107fed1fa6d802c4dea4cfc7fb604ff1c9edbe747084b4089a4d1db3a",
+                "sha256:fa290a202446630cc71593712bea548f296b89cb8a4161002c2e03afc3b2ffed",
+                "sha256:fbeb1ed7228fc406229c8693f8a02b8e064f7a9979665ac0181c983667cc383c"
+            ],
+            "version": "==1.5.3"
+        },
+        "greenlet": {
+            "hashes": [
+                "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711",
+                "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd",
+                "sha256:049fe7579230e44daef03a259faa24511d10ebfa44f69411d99e6a184fe68073",
+                "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708",
+                "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67",
+                "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23",
+                "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1",
+                "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08",
+                "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd",
+                "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa",
+                "sha256:356b3576ad078c89a6107caa9c50cc14e98e3a6c4874a37c3e0273e4baf33de8",
+                "sha256:40b951f601af999a8bf2ce8c71e8aaa4e8c6f78ff8afae7b808aae2dc50d4c40",
+                "sha256:572e1787d1460da79590bf44304abbc0a2da944ea64ec549188fa84d89bba7ab",
+                "sha256:58df5c2a0e293bf665a51f8a100d3e9956febfbf1d9aaf8c0677cf70218910c6",
+                "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc",
+                "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b",
+                "sha256:7418b6bfc7fe3331541b84bb2141c9baf1ec7132a7ecd9f375912eca810e714e",
+                "sha256:7cbd7574ce8e138bda9df4efc6bf2ab8572c9aff640d8ecfece1b006b68da963",
+                "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3",
+                "sha256:833e1551925ed51e6b44c800e71e77dacd7e49181fdc9ac9a0bf3714d515785d",
+                "sha256:8639cadfda96737427330a094476d4c7a56ac03de7265622fcf4cfe57c8ae18d",
+                "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28",
+                "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3",
+                "sha256:903bbd302a2378f984aef528f76d4c9b1748f318fe1294961c072bdc7f2ffa3e",
+                "sha256:93f81b134a165cc17123626ab8da2e30c0455441d4ab5576eed73a64c025b25c",
+                "sha256:95e69877983ea39b7303570fa6760f81a3eec23d0e3ab2021b7144b94d06202d",
+                "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0",
+                "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497",
+                "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee",
+                "sha256:aa5b467f15e78b82257319aebc78dd2915e4c1436c3c0d1ad6f53e47ba6e2713",
+                "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58",
+                "sha256:aec52725173bd3a7b56fe91bc56eccb26fbdff1386ef123abb63c84c5b43b63a",
+                "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06",
+                "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88",
+                "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4",
+                "sha256:be5f425ff1f5f4b3c1e33ad64ab994eed12fc284a6ea71c5243fd564502ecbe5",
+                "sha256:dd0b1e9e891f69e7675ba5c92e28b90eaa045f6ab134ffe70b52e948aa175b3c",
+                "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a",
+                "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1",
+                "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43",
+                "sha256:eb6ea6da4c787111adf40f697b4e58732ee0942b5d3bd8f435277643329ba627",
+                "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b",
+                "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168",
+                "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d",
+                "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5",
+                "sha256:f3acda1924472472ddd60c29e5b9db0cec629fbe3c5c5accb74d6d6d14773478",
+                "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf",
+                "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce",
+                "sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c",
+                "sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b"
+            ],
+            "markers": "platform_python_implementation == 'CPython'",
+            "version": "==1.1.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.3"
+        },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
+        },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
+                "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8",
+                "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.3"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:2a0f162822a64d95287990481b45d82f096e99721c86534f48201b64ebca6e8c",
+                "sha256:390713469ae64b8a58698bb3cbc3859abe6925b565a973f87323ef21b09a27a8"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.2.1"
+        },
+        "locust": {
+            "hashes": [
+                "sha256:17bffcc3c7ade9e72aa59997c5a8d8bd7aa5cc2b6063637804cd80366b75fa44",
+                "sha256:975e29ad9019db3c5d29eeea7d087c5fd2b643fdbbf1161d445da9fc4308a620"
+            ],
+            "index": "pypi",
+            "version": "==2.5.0"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
+                "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a",
+                "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
+                "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38",
+                "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
+                "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1",
+                "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
+                "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee",
+                "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86",
+                "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
+                "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f",
+                "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
+                "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
+                "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a",
+                "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
+                "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd",
+                "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
+                "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
+                "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
+        },
+        "msgpack": {
+            "hashes": [
+                "sha256:0cb94ee48675a45d3b86e61d13c1e6f1696f0183f0715544976356ff86f741d9",
+                "sha256:1026dcc10537d27dd2d26c327e552f05ce148977e9d7b9f1718748281b38c841",
+                "sha256:26a1759f1a88df5f1d0b393eb582ec022326994e311ba9c5818adc5374736439",
+                "sha256:2a5866bdc88d77f6e1370f82f2371c9bc6fc92fe898fa2dec0c5d4f5435a2694",
+                "sha256:31c17bbf2ae5e29e48d794c693b7ca7a0c73bd4280976d408c53df421e838d2a",
+                "sha256:497d2c12426adcd27ab83144057a705efb6acc7e85957a51d43cdcf7f258900f",
+                "sha256:5a9ee2540c78659a1dd0b110f73773533ee3108d4e1219b5a15a8d635b7aca0e",
+                "sha256:8521e5be9e3b93d4d5e07cb80b7e32353264d143c1f072309e1863174c6aadb1",
+                "sha256:87869ba567fe371c4555d2e11e4948778ab6b59d6cc9d8460d543e4cfbbddd1c",
+                "sha256:8ffb24a3b7518e843cd83538cf859e026d24ec41ac5721c18ed0c55101f9775b",
+                "sha256:92be4b12de4806d3c36810b0fe2aeedd8d493db39e2eb90742b9c09299eb5759",
+                "sha256:9ea52fff0473f9f3000987f313310208c879493491ef3ccf66268eff8d5a0326",
+                "sha256:a4355d2193106c7aa77c98fc955252a737d8550320ecdb2e9ac701e15e2943bc",
+                "sha256:a99b144475230982aee16b3d249170f1cccebf27fb0a08e9f603b69637a62192",
+                "sha256:ac25f3e0513f6673e8b405c3a80500eb7be1cf8f57584be524c4fa78fe8e0c83",
+                "sha256:b28c0876cce1466d7c2195d7658cf50e4730667196e2f1355c4209444717ee06",
+                "sha256:b55f7db883530b74c857e50e149126b91bb75d35c08b28db12dcb0346f15e46e",
+                "sha256:b6d9e2dae081aa35c44af9c4298de4ee72991305503442a5c74656d82b581fe9",
+                "sha256:c747c0cc08bd6d72a586310bda6ea72eeb28e7505990f342552315b229a19b33",
+                "sha256:d6c64601af8f3893d17ec233237030e3110f11b8a962cb66720bf70c0141aa54",
+                "sha256:d8167b84af26654c1124857d71650404336f4eb5cc06900667a493fc619ddd9f",
+                "sha256:de6bd7990a2c2dabe926b7e62a92886ccbf809425c347ae7de277067f97c2887",
+                "sha256:e36a812ef4705a291cdb4a2fd352f013134f26c6ff63477f20235138d1d21009",
+                "sha256:e89ec55871ed5473a041c0495b7b4e6099f6263438e0bd04ccd8418f92d5d7f2",
+                "sha256:f3e6aaf217ac1c7ce1563cf52a2f4f5d5b1f64e8729d794165db71da57257f0c",
+                "sha256:f484cd2dca68502de3704f056fa9b318c94b1539ed17a4c784266df5d6978c87",
+                "sha256:fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984",
+                "sha256:fe07bc6735d08e492a327f496b7850e98cb4d112c56df69b0c844dbebcbb47f6"
+            ],
+            "version": "==1.0.2"
+        },
+        "openapi-schema-validator": {
+            "hashes": [
+                "sha256:215b516d0942f4e8e2446cf3f7d4ff2ed71d102ebddcc30526d8a3f706ab1df6",
+                "sha256:a4b2712020284cee880b4c55faa513fbc2f8f07f365deda6098f8ab943c9f0df",
+                "sha256:b65d6c2242620bfe76d4c749b61cd9657e4528895a8f4fb6f916085b508ebd24"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.1.5"
+        },
+        "openapi-spec-validator": {
+            "hashes": [
+                "sha256:0a7da925bad4576f4518f77302c0b1990adb2fbcbe7d63fb4ed0de894cad8bdd",
+                "sha256:3d70e6592754799f7e77a45b98c6a91706bdd309a425169d17d8e92173e198a2",
+                "sha256:ba28b06e63274f2bc6de995a07fb572c657e534425b5baf68d9f7911efe6929f"
+            ],
+            "version": "==0.3.1"
+        },
+        "prance": {
+            "extras": [
+                "cli",
+                "osv"
+            ],
+            "hashes": [
+                "sha256:86ec64378036471efdd9681648d8da6b39e5143ea2e6981b7863a33fbc75d739",
+                "sha256:b87504dffb40c1e29aca0ca01f5f3dbb1941f29fd32c3a5e0fbd90ae37f749a3"
+            ],
+            "index": "pypi",
+            "version": "==0.19.0"
+        },
+        "psutil": {
+            "hashes": [
+                "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64",
+                "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131",
+                "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c",
+                "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6",
+                "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023",
+                "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df",
+                "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394",
+                "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4",
+                "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b",
+                "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2",
+                "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d",
+                "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65",
+                "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d",
+                "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef",
+                "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7",
+                "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60",
+                "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6",
+                "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8",
+                "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b",
+                "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d",
+                "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac",
+                "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935",
+                "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d",
+                "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28",
+                "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876",
+                "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0",
+                "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3",
+                "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==5.8.0"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2",
+                "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7",
+                "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea",
+                "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426",
+                "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710",
+                "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1",
+                "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396",
+                "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2",
+                "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680",
+                "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35",
+                "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427",
+                "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b",
+                "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b",
+                "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f",
+                "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef",
+                "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c",
+                "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4",
+                "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d",
+                "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78",
+                "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b",
+                "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.18.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.8.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
+        },
+        "pyzmq": {
+            "hashes": [
+                "sha256:08c4e315a76ef26eb833511ebf3fa87d182152adf43dedee8d79f998a2162a0b",
+                "sha256:0ca6cd58f62a2751728016d40082008d3b3412a7f28ddfb4a2f0d3c130f69e74",
+                "sha256:1621e7a2af72cced1f6ec8ca8ca91d0f76ac236ab2e8828ac8fe909512d566cb",
+                "sha256:18cd854b423fce44951c3a4d3e686bac8f1243d954f579e120a1714096637cc0",
+                "sha256:2841997a0d85b998cbafecb4183caf51fd19c4357075dfd33eb7efea57e4c149",
+                "sha256:2b97502c16a5ec611cd52410bdfaab264997c627a46b0f98d3f666227fd1ea2d",
+                "sha256:3a4c9886d61d386b2b493377d980f502186cd71d501fffdba52bd2a0880cef4f",
+                "sha256:3c1895c95be92600233e476fe283f042e71cf8f0b938aabf21b7aafa62a8dac9",
+                "sha256:42abddebe2c6a35180ca549fadc7228d23c1e1f76167c5ebc8a936b5804ea2df",
+                "sha256:468bd59a588e276961a918a3060948ae68f6ff5a7fa10bb2f9160c18fe341067",
+                "sha256:480b9931bfb08bf8b094edd4836271d4d6b44150da051547d8c7113bf947a8b0",
+                "sha256:53f4fd13976789ffafedd4d46f954c7bb01146121812b72b4ddca286034df966",
+                "sha256:62bcade20813796c426409a3e7423862d50ff0639f5a2a95be4b85b09a618666",
+                "sha256:67db33bea0a29d03e6eeec55a8190e033318cee3cbc732ba8fd939617cbf762d",
+                "sha256:6b217b8f9dfb6628f74b94bdaf9f7408708cb02167d644edca33f38746ca12dd",
+                "sha256:7661fc1d5cb73481cf710a1418a4e1e301ed7d5d924f91c67ba84b2a1b89defd",
+                "sha256:76c532fd68b93998aab92356be280deec5de8f8fe59cd28763d2cc8a58747b7f",
+                "sha256:79244b9e97948eaf38695f4b8e6fc63b14b78cc37f403c6642ba555517ac1268",
+                "sha256:7c58f598d9fcc52772b89a92d72bf8829c12d09746a6d2c724c5b30076c1f11d",
+                "sha256:7dc09198e4073e6015d9a8ea093fc348d4e59de49382476940c3dd9ae156fba8",
+                "sha256:80e043a89c6cadefd3a0712f8a1322038e819ebe9dbac7eca3bce1721bcb63bf",
+                "sha256:851977788b9caa8ed011f5f643d3ee8653af02c5fc723fa350db5125abf2be7b",
+                "sha256:8eddc033e716f8c91c6a2112f0a8ebc5e00532b4a6ae1eb0ccc48e027f9c671c",
+                "sha256:902319cfe23366595d3fa769b5b751e6ee6750a0a64c5d9f757d624b2ac3519e",
+                "sha256:954e73c9cd4d6ae319f1c936ad159072b6d356a92dcbbabfd6e6204b9a79d356",
+                "sha256:ab888624ed68930442a3f3b0b921ad7439c51ba122dbc8c386e6487a658e4a4e",
+                "sha256:acebba1a23fb9d72b42471c3771b6f2f18dcd46df77482612054bd45c07dfa36",
+                "sha256:b4ebed0977f92320f6686c96e9e8dd29eed199eb8d066936bac991afc37cbb70",
+                "sha256:badb868fff14cfd0e200eaa845887b1011146a7d26d579aaa7f966c203736b92",
+                "sha256:be4e0f229cf3a71f9ecd633566bd6f80d9fa6afaaff5489492be63fe459ef98c",
+                "sha256:c0f84360dcca3481e8674393bdf931f9f10470988f87311b19d23cda869bb6b7",
+                "sha256:c1e41b32d6f7f9c26bc731a8b529ff592f31fc8b6ef2be9fa74abd05c8a342d7",
+                "sha256:c88fa7410e9fc471e0858638f403739ee869924dd8e4ae26748496466e27ac59",
+                "sha256:cf98fd7a6c8aaa08dbc699ffae33fd71175696d78028281bc7b832b26f00ca57",
+                "sha256:d072f7dfbdb184f0786d63bda26e8a0882041b1e393fbe98940395f7fab4c5e2",
+                "sha256:d1b5d457acbadcf8b27561deeaa386b0217f47626b29672fa7bd31deb6e91e1b",
+                "sha256:d3dcb5548ead4f1123851a5ced467791f6986d68c656bc63bfff1bf9e36671e2",
+                "sha256:d6157793719de168b199194f6b6173f0ccd3bf3499e6870fac17086072e39115",
+                "sha256:d728b08448e5ac3e4d886b165385a262883c34b84a7fe1166277fe675e1c197a",
+                "sha256:de8df0684398bd74ad160afdc2a118ca28384ac6f5e234eb0508858d8d2d9364",
+                "sha256:e6a02cf7271ee94674a44f4e62aa061d2d049001c844657740e156596298b70b",
+                "sha256:ea12133df25e3a6918718fbb9a510c6ee5d3fdd5a346320421aac3882f4feeea",
+                "sha256:ea5a79e808baef98c48c884effce05c31a0698c1057de8fc1c688891043c1ce1",
+                "sha256:f43b4a2e6218371dd4f41e547bd919ceeb6ebf4abf31a7a0669cd11cd91ea973",
+                "sha256:f762442bab706fd874064ca218b33a1d8e40d4938e96c24dafd9b12e28017f45",
+                "sha256:f89468059ebc519a7acde1ee50b779019535db8dcf9b8c162ef669257fef7a93",
+                "sha256:f907c7359ce8bf7f7e63c82f75ad0223384105f5126f313400b7e8004d9b33c3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==22.3.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+            ],
+            "index": "pypi",
+            "version": "==2.26.0"
+        },
+        "roundrobin": {
+            "hashes": [
+                "sha256:ac30cb78570a36bb0ce0db7b907af9394ec7a5610ece2ede072280e8dd867caa"
+            ],
+            "version": "==0.0.2"
+        },
+        "semver": {
+            "hashes": [
+                "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4",
+                "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.13.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.16.0"
+        },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
+            ],
+            "version": "==1.3"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed",
+                "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.7"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f",
+                "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.2"
+        },
+        "zope.event": {
+            "hashes": [
+                "sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42",
+                "sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330"
+            ],
+            "version": "==4.5.0"
+        },
+        "zope.interface": {
+            "hashes": [
+                "sha256:08f9636e99a9d5410181ba0729e0408d3d8748026ea938f3b970a0249daa8192",
+                "sha256:0b465ae0962d49c68aa9733ba92a001b2a0933c317780435f00be7ecb959c702",
+                "sha256:0cba8477e300d64a11a9789ed40ee8932b59f9ee05f85276dbb4b59acee5dd09",
+                "sha256:0cee5187b60ed26d56eb2960136288ce91bcf61e2a9405660d271d1f122a69a4",
+                "sha256:0ea1d73b7c9dcbc5080bb8aaffb776f1c68e807767069b9ccdd06f27a161914a",
+                "sha256:0f91b5b948686659a8e28b728ff5e74b1be6bf40cb04704453617e5f1e945ef3",
+                "sha256:15e7d1f7a6ee16572e21e3576d2012b2778cbacf75eb4b7400be37455f5ca8bf",
+                "sha256:17776ecd3a1fdd2b2cd5373e5ef8b307162f581c693575ec62e7c5399d80794c",
+                "sha256:194d0bcb1374ac3e1e023961610dc8f2c78a0f5f634d0c737691e215569e640d",
+                "sha256:1c0e316c9add0db48a5b703833881351444398b04111188069a26a61cfb4df78",
+                "sha256:205e40ccde0f37496904572035deea747390a8b7dc65146d30b96e2dd1359a83",
+                "sha256:273f158fabc5ea33cbc936da0ab3d4ba80ede5351babc4f577d768e057651531",
+                "sha256:2876246527c91e101184f63ccd1d716ec9c46519cc5f3d5375a3351c46467c46",
+                "sha256:2c98384b254b37ce50eddd55db8d381a5c53b4c10ee66e1e7fe749824f894021",
+                "sha256:2e5a26f16503be6c826abca904e45f1a44ff275fdb7e9d1b75c10671c26f8b94",
+                "sha256:334701327f37c47fa628fc8b8d28c7d7730ce7daaf4bda1efb741679c2b087fc",
+                "sha256:3748fac0d0f6a304e674955ab1365d515993b3a0a865e16a11ec9d86fb307f63",
+                "sha256:3c02411a3b62668200910090a0dff17c0b25aaa36145082a5a6adf08fa281e54",
+                "sha256:3dd4952748521205697bc2802e4afac5ed4b02909bb799ba1fe239f77fd4e117",
+                "sha256:3f24df7124c323fceb53ff6168da70dbfbae1442b4f3da439cd441681f54fe25",
+                "sha256:469e2407e0fe9880ac690a3666f03eb4c3c444411a5a5fddfdabc5d184a79f05",
+                "sha256:4de4bc9b6d35c5af65b454d3e9bc98c50eb3960d5a3762c9438df57427134b8e",
+                "sha256:5208ebd5152e040640518a77827bdfcc73773a15a33d6644015b763b9c9febc1",
+                "sha256:52de7fc6c21b419078008f697fd4103dbc763288b1406b4562554bd47514c004",
+                "sha256:5bb3489b4558e49ad2c5118137cfeaf59434f9737fa9c5deefc72d22c23822e2",
+                "sha256:5dba5f530fec3f0988d83b78cc591b58c0b6eb8431a85edd1569a0539a8a5a0e",
+                "sha256:5dd9ca406499444f4c8299f803d4a14edf7890ecc595c8b1c7115c2342cadc5f",
+                "sha256:5f931a1c21dfa7a9c573ec1f50a31135ccce84e32507c54e1ea404894c5eb96f",
+                "sha256:63b82bb63de7c821428d513607e84c6d97d58afd1fe2eb645030bdc185440120",
+                "sha256:66c0061c91b3b9cf542131148ef7ecbecb2690d48d1612ec386de9d36766058f",
+                "sha256:6f0c02cbb9691b7c91d5009108f975f8ffeab5dff8f26d62e21c493060eff2a1",
+                "sha256:71aace0c42d53abe6fc7f726c5d3b60d90f3c5c055a447950ad6ea9cec2e37d9",
+                "sha256:7d97a4306898b05404a0dcdc32d9709b7d8832c0c542b861d9a826301719794e",
+                "sha256:7df1e1c05304f26faa49fa752a8c690126cf98b40b91d54e6e9cc3b7d6ffe8b7",
+                "sha256:8270252effc60b9642b423189a2fe90eb6b59e87cbee54549db3f5562ff8d1b8",
+                "sha256:867a5ad16892bf20e6c4ea2aab1971f45645ff3102ad29bd84c86027fa99997b",
+                "sha256:877473e675fdcc113c138813a5dd440da0769a2d81f4d86614e5d62b69497155",
+                "sha256:8892f89999ffd992208754851e5a052f6b5db70a1e3f7d54b17c5211e37a98c7",
+                "sha256:9a9845c4c6bb56e508651f005c4aeb0404e518c6f000d5a1123ab077ab769f5c",
+                "sha256:a1e6e96217a0f72e2b8629e271e1b280c6fa3fe6e59fa8f6701bec14e3354325",
+                "sha256:a8156e6a7f5e2a0ff0c5b21d6bcb45145efece1909efcbbbf48c56f8da68221d",
+                "sha256:a9506a7e80bcf6eacfff7f804c0ad5350c8c95b9010e4356a4b36f5322f09abb",
+                "sha256:af310ec8335016b5e52cae60cda4a4f2a60a788cbb949a4fbea13d441aa5a09e",
+                "sha256:b0297b1e05fd128d26cc2460c810d42e205d16d76799526dfa8c8ccd50e74959",
+                "sha256:bf68f4b2b6683e52bec69273562df15af352e5ed25d1b6641e7efddc5951d1a7",
+                "sha256:d0c1bc2fa9a7285719e5678584f6b92572a5b639d0e471bb8d4b650a1a910920",
+                "sha256:d4d9d6c1a455d4babd320203b918ccc7fcbefe308615c521062bc2ba1aa4d26e",
+                "sha256:db1fa631737dab9fa0b37f3979d8d2631e348c3b4e8325d6873c2541d0ae5a48",
+                "sha256:dd93ea5c0c7f3e25335ab7d22a507b1dc43976e1345508f845efc573d3d779d8",
+                "sha256:f44e517131a98f7a76696a7b21b164bcb85291cee106a23beccce454e1f433a4",
+                "sha256:f7ee479e96f7ee350db1cf24afa5685a5899e2b34992fb99e1f7c1b0b758d263"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==5.4.0"
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:6eb7448da9143ee65b856a5f3676b7dda98ad9abe0f87fce8c59291f15e82a5b",
+                "sha256:a9952229092e325fe5f3dae56d81f639b23f7131eb840781947e4b2886030f33"
+            ],
+            "index": "pypi",
+            "version": "==21.10b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "version": "==7.1.2"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20",
+                "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.17.2"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966",
+                "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.2"
+        },
+        "parso": {
+            "hashes": [
+                "sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea",
+                "sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.7.1"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2",
+                "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.4.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+            ],
+            "index": "pypi",
+            "version": "==6.2.5"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3",
+                "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"
+            ],
+            "index": "pypi",
+            "version": "==3.6.1"
+        },
+        "python-jsonrpc-server": {
+            "hashes": [
+                "sha256:62c543e541f101ec5b57dc654efc212d2c2e3ea47ff6f54b2e7dcb36ecf20595",
+                "sha256:e5a908ff182e620aac07db5f57887eeb0afe33993008f57dc1b85b594cea250c"
+            ],
+            "version": "==0.4.0"
+        },
+        "python-language-server": {
+            "hashes": [
+                "sha256:9984c84a67ee2c5102c8e703215f407fcfa5e62b0ae86c9572d0ada8c4b417b0",
+                "sha256:a0ad0aca03f4a20c1c40f4f230c6773eac82c9b7cdb026cb09ba10237f4815d5"
+            ],
+            "index": "pypi",
+            "version": "==0.36.2"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f",
+                "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc",
+                "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4",
+                "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4",
+                "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8",
+                "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f",
+                "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a",
+                "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef",
+                "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f",
+                "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc",
+                "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50",
+                "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d",
+                "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d",
+                "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733",
+                "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36",
+                "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345",
+                "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0",
+                "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12",
+                "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646",
+                "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667",
+                "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244",
+                "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29",
+                "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec",
+                "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf",
+                "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4",
+                "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449",
+                "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a",
+                "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d",
+                "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb",
+                "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e",
+                "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83",
+                "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e",
+                "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a",
+                "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94",
+                "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc",
+                "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e",
+                "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965",
+                "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0",
+                "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36",
+                "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec",
+                "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23",
+                "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7",
+                "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe",
+                "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6",
+                "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b",
+                "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb",
+                "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b",
+                "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30",
+                "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"
+            ],
+            "version": "==2021.11.10"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee",
+                "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.2"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed",
+                "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.0"
+        },
+        "ujson": {
+            "hashes": [
+                "sha256:0076de81aadc287f025525969bbc1272703be92933e988e5663a76ec5863628f",
+                "sha256:02f5a6acc5aa5b054c32bdccd17064c2cbd07c81b3a49449589a4552888f1961",
+                "sha256:0d61ae7a505105a16220a4282dbd552bef76968203e5e4f5edfdbb03d3159e3a",
+                "sha256:0db1acd8dbbf120095ce4ab118585219066ea2860332df2385a435c585036cae",
+                "sha256:0ebc82847938e417092fd463e593da39a280fd12585b998e435a2a45bb7a33f7",
+                "sha256:26e299caa9bfc2e532e16de38de2af48cde48258922cda5efc0dd447d42692fc",
+                "sha256:26ebe3ac1e0d18d58e11dbf7cdd0459adcefd5c025ede99be7fceae47bd1bfc6",
+                "sha256:32f4340c8d6a34e7fa1f9447919ebd4b6256afef0965868d51ea3cdf0694a8f7",
+                "sha256:3697cae44a92c2264cf307d4cdd9ea436faa75a009d35a4097362a6bbf221a1b",
+                "sha256:40235c3704ac7f29b24a7a785f856e1c45a567c8cd4b57a025f516733e358972",
+                "sha256:42f8def3e44d880774f644b53b4701a46889a9506e3fdc191c314c9e2e9b2a38",
+                "sha256:50ddff58727cc4f90ade4c818884c4f0fbeeb1f78f764ab2b2bc89cf1f4db126",
+                "sha256:50f413177206373b3568dff28c091b2d8c9145e5e54b0a524d3823293d7a29b8",
+                "sha256:535f1e5b336f7a0573da59bd9352e9cc6a93185bf4b1d96fb3379e07b4fc619a",
+                "sha256:5a885675252e041e19cb92ff76419251fdd1ab4c2ca9766cb3ecfa6ae07884d2",
+                "sha256:5f863b12d27867b733d380a9878fc8c3ad11d3aea8a3650c33e7a8c2a888e1eb",
+                "sha256:6182898d7031d083017f9be47c6d57f9c2155d9f4391b77ed6c020cab8e5a471",
+                "sha256:68088596e237dcda862c1760d1feb2236a8cc36804507a9fcfaa3ed21442ff64",
+                "sha256:6bccfff9910fbe3dae6a17ec080c48fca0bfe939b18e4b2622122109d4d2570d",
+                "sha256:6e8c30186eaa4f982b9b56cad30b173b71aac9d6a393d97cbcbc4ca805e87943",
+                "sha256:74961587e9c1682d3e04fe29e02b67ec9c88cb0c3406ad94cc617d04c6fa6db2",
+                "sha256:78f8da27231b20d589319f743bd65011862691c102922be85c9f27e40656a0f7",
+                "sha256:8ec19982b7a40fb526b8ffd6edfff2c5c10556a54416d554c4bc83b1e4140a4c",
+                "sha256:944dfdfae0cb4e4274a23e5070be913f7ff8f05666d8d143f2356cf873f9a77a",
+                "sha256:99322e08e53580867c9909637747343354b7028a8208dc5df3d09233c8f52c30",
+                "sha256:a6e27ff0f92c719de004b806d84f471fff0157679e57517092b8f89345eb3a79",
+                "sha256:ab70a29914fc202f7c8f6353bb0622b91f878e2892e57a4c7293b341d5a85133",
+                "sha256:adca402a97b8388c378d92c55b2bf4e8402baa5dfa059a85870a41e2f142a0d0",
+                "sha256:b55dde52028f3c426197b9a928618fbb2b548172eb45824ddb19cdcdf8e493f9",
+                "sha256:bac42d0131740b6f1d2b6a15f770c1fef0db97d05aba8564f3c75bb59a9c91c7",
+                "sha256:bc9e2e6933ecec17a7d351116f555caee84b798076a4c5276ab1e8654c83bd90",
+                "sha256:bff484c162bd77877bc9ae6333b0a684493037ce3c5d8b664e8339becf9ad139",
+                "sha256:c53653a12f6ce67b12e7806c190cce1db09c75de31212a5a9adbdbd7a2aba116",
+                "sha256:c7b2643b063f33e5e0d539cf2811793a7df9da525e63483f70c9262a343bd59d",
+                "sha256:c9723a5e2743ded9bc6106cb04f86244dd779ad847d8ac189cfe808ab16946c1",
+                "sha256:cf272e6302c62a42ed0125efcc1d891dd909bcfb3c6aa075d89de209b2b8e930",
+                "sha256:d0abc1526d32ebe2f2b6fefcf82b9ee8661da3f45ecac087beee6aeaa21b39ec",
+                "sha256:d9a0252da73d8b69de60811252cbfde215d76ee6eea935a519e223353352026c",
+                "sha256:dd98d659365fb9271d9f9ba21160670ddfecb93deaec8a5350519a0ab3604654",
+                "sha256:e7c8cffd9e45248569fa576d19b043951a3edc67cbee3dca2a6b77e6998cb1ec",
+                "sha256:fa68b25c987b73fb1c83ece34e52856c2c6da3031384f72638696c56fa8baca9",
+                "sha256:fae1e251d9f9362ebc4adbbb252d0f4a023f66f180390624826fcb1812b808e9",
+                "sha256:ff0ae4b1dc70c3362b04f4127e228b17e84946de611f85b32f565b990762deaf",
+                "sha256:fffe509f556861c7343c6cba57ed05fe7bcf4b48a934a5b946ccb45428cf8883"
+            ],
+            "markers": "python_version > '3'",
+            "version": "==4.2.0"
+        }
+    }
+}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "64f0450461c09a147326e998e7d98d12855d8d12f079bd08361794fce05e20ed"
+            "sha256": "979b7d5bac9412e824531568752200e304d87849a59b7cef8eee4cd8e9ed0241"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -889,11 +889,11 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20",
-                "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"
+                "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93",
+                "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.17.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.18.0"
         },
         "mccabe": {
             "hashes": [
@@ -919,11 +919,11 @@
         },
         "parso": {
             "hashes": [
-                "sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea",
-                "sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9"
+                "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398",
+                "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.7.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.8.2"
         },
         "pathspec": {
             "hashes": [
@@ -1003,20 +1003,20 @@
             "index": "pypi",
             "version": "==3.6.1"
         },
-        "python-jsonrpc-server": {
+        "python-lsp-jsonrpc": {
             "hashes": [
-                "sha256:62c543e541f101ec5b57dc654efc212d2c2e3ea47ff6f54b2e7dcb36ecf20595",
-                "sha256:e5a908ff182e620aac07db5f57887eeb0afe33993008f57dc1b85b594cea250c"
+                "sha256:079b143be64b0a378bdb21dff5e28a8c1393fe7e8a654ef068322d754e545fc7",
+                "sha256:7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd"
             ],
-            "version": "==0.4.0"
+            "version": "==1.0.0"
         },
-        "python-language-server": {
+        "python-lsp-server": {
             "hashes": [
-                "sha256:9984c84a67ee2c5102c8e703215f407fcfa5e62b0ae86c9572d0ada8c4b417b0",
-                "sha256:a0ad0aca03f4a20c1c40f4f230c6773eac82c9b7cdb026cb09ba10237f4815d5"
+                "sha256:007278c4419339bd3a61ca6d7eb8648ead28b5f1b9eba3b6bae8540046116335",
+                "sha256:a163907c83ba7bae6b45a9bc9e407b7001fbed7c7561d032a5fd355ae6fae42c"
             ],
             "index": "pypi",
-            "version": "==0.36.2"
+            "version": "==1.2.4"
         },
         "regex": {
             "hashes": [
@@ -1167,7 +1167,7 @@
                 "sha256:ff0ae4b1dc70c3362b04f4127e228b17e84946de611f85b32f565b990762deaf",
                 "sha256:fffe509f556861c7343c6cba57ed05fe7bcf4b48a934a5b946ccb45428cf8883"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version >= '3.6'",
             "version": "==4.2.0"
         },
         "urllib3": {

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the [LICENSE.txt](./LICENSE.txt) file in this repository.
     * [Deploying New Tests](#deploying-new-tests)
   * [Fake Data Generation](#fake-data-generation)
     * [Creating a custom parser](#creating-a-custom-parser)
-  * [Load Testing against AWS Experimental Environment](#load-testing-against-aws-experimental-environment)
+  * [Load Testing against AWS Loadtest Environment](#load-testing-against-aws-loatest-environment)
     * [Prime API](#prime-api)
     * [MilMove/Office domains](#milmoveoffice-domains)
     * [Handling Rate Limiting](#handling-rate-limiting)
@@ -306,10 +306,10 @@ commands include:
 Each of these commands opens the Locust interface for initiating and monitoring the tests, set
 to [http://localhost:8089](http://localhost:8089). Using this interface, you can set the number of users to simulate and
 their hatch rate, then start and stop the test at will. For the host, you can enter a full URL address, or you can
-simply enter "local" or "exp" (for experimental), and let the system set the URL as appropriate.
+simply enter "local" or "dp3" (for loadtest), and let the system set the URL as appropriate.
 
-**NOTE: Currently the system only functions in the local environment. You may try the other settings for fun, but don't
-expect them to work.**
+**NOTE: Currently the system only functions in the local or dp3
+environment. You may try the other settings for fun, but don't expect them to work.**
 
 ### Running custom tests
 
@@ -317,7 +317,7 @@ If you need more control over the parameters for a load test, you will need to r
 look something like:
 
 ```sh
-locust -f locustfiles/<file_to_test>.py --host <local/exp>
+locust -f locustfiles/<file_to_test>.py --host <local/dp3>
 ```
 
 Ex:
@@ -330,6 +330,8 @@ For more information on running custom tests, refer to
 the [wiki](https://github.com/transcom/milmove_load_testing/wiki/Running-Load-Tests-Against-MyMove)
 
 ### Running Tests for Reporting
+
+*NOTE*: THESE COMMAND ARE DEPRECATED AND NOT WORKING AS OF 2021-11-17
 
 There are a couple of preset tests that have been set up to generate reports for later analysis. These commands are:
 
@@ -362,7 +364,7 @@ from locust import HttpUser, between
 from utils.hosts import MilMoveHostMixin, MilMoveDomain
 
 
-# Use MilMoveHostMixin to easily switch between local and experimental environments
+# Use MilMoveHostMixin to easily switch between local and dp3 environments
 # HttpUser is the Locust user class we want to use to hit endpoint paths
 class MyUser(MilMoveHostMixin, HttpUser):
   """ Here's a short description of what my user does. """
@@ -692,7 +694,7 @@ GHCTaskSet(ParserTaskMixin, ...):
         print(response.status_code, response.content)
 ```
 
-## Load Testing against AWS Experimental Environment
+## Load Testing against AWS Loadtest Environment
 
 ### Prime API
 
@@ -704,7 +706,7 @@ these steps. Otherwise, please follow the instructions in the `mymove` repo to c
 * [Setup: AWS credentials and `aws-vault`](https://github.com/transcom/mymove#setup-aws-services-optional)
 
 Once you have loaded the secrets from `chamber`, which will include the experimental certificate and private key, you
-may run your load tests using "exp" as the host value. It is strongly recommended that you set up your `User` classes to
+may run your load tests using "dp3" as the host value. It is strongly recommended that you set up your `User` classes to
 subclass `MilMoveHostMixin` so that your TLS settings are automatically updated when you switch from "local" to "exp."
 
 ### MilMove/Office domains
@@ -714,16 +716,17 @@ To load test against the AWS Experimental Environment you must modify the
 and [deploy the code to the experimental environment](https://github.com/transcom/mymove/wiki/deploy-to-experimental).
 
 Then, if you have `User` classes that take advantage of the `MilMoveHostMixin` class, you may run your load tests using
-"exp" as the host value. If not, make sure to use the experimental domains as your host:
+"dp3" as the host value. If not, make sure to use the loadtest domains as your host:
 
-* [https://my.exp.move.mil](https://my.exp.move.mil)
-* [https://office.exp.move.mil](https://office.exp.move.mil)
+* [https://my.loadtest.dp3.us](https://my.loadtest.dp3.us)
+* [https://office.loadtest.dp3.us](https://office.loadtest.dp3.us)
 
 ### Handling Rate Limiting
 
 Each environment is set to limit the number of requests from a single IP in a 5 minute period. That limit is usually
 2000. For load testing it's likely you'll want a much higher limit, perhaps even 10 times as high. Work with
-infrastructure to modify the limit. Here is the diff to apply:
+infrastructure to modify the limit. Here is the diff to apply (but
+you'll want to do this against the loadtest config:
 
 ```diff
 diff --git a/transcom-ppp/app-experimental/main.tf b/transcom-ppp/app-experimental/main.tf
@@ -743,8 +746,8 @@ index 4ef1a29..bac3cf7 100644
 
 You will want to see metrics from your runs:
 
-* [app-experimental cluster metrics](https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/clusters/app-experimental/services/app/metrics)
-* [app-experimental CloudWatch dashboard](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#dashboards:name=mil-experimental)
+* [app-experimental cluster metrics](https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#cw:dashboard=ECS)
+* [app-experimental CloudWatch dashboard](https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#dashboards:name=CloudWatch-Default)
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -122,15 +122,21 @@ search for alternatives if you are running a different OS.*
 
 We have two supported installation methods, `pyenv` and `nix`. Pick which you prefer and proceed to that section.
 
-#### Setup: Pyenv
+#### Setup: Pyenv and Pipenv
 
-* Run
+When setting up for the first time, before you run `direnv allow`, run
 
   ```shell
   make install_tools
   ```
 
-  This will install `pyenv` along with other tools like `pyenv-virtualenv` and `pre-commit`.
+This will install `pyenv` and `pipenv` along with other tools like `pre-commit`. Now run
+
+  ```shell
+  direnv allow
+  ```
+
+This should install the dependencies via `pipenv` automatically.
 
 If the base dependencies change, you can always re-run this command.
 
@@ -166,9 +172,7 @@ level of this repo and reload your shell.
   This will install all the `python` dependencies in `requirements.txt` and `requirements-dev.txt`. It will also install
   the `pre-commit` hooks.
 
-*Note: The requirements are indicated in the `requirements.txt` and `requirements-dev.txt` files. `requirements.txt`
-contains the pip-installed requirements needed to run the project. `requirements-dev.txt` contains the requirements to
-lint and format our code if you wish to contribute - they are not functional requirements to run the code.*
+*Note: The requirements are indicated in the `Pipenv` file.
 
 ### Unsupported Setup
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ the [LICENSE.txt](./LICENSE.txt) file in this repository.
 <!-- Uses gh-md-toc to generate Table of Contents: https://github.com/ekalinin/github-markdown-toc -->
 <!-- markdownlint-disable -->
 <!--ts-->
-
 * [MilMove Load Testing](#milmove-load-testing)
   * [License Information](#license-information)
   * [Table of Contents](#table-of-contents)
@@ -25,9 +24,11 @@ the [LICENSE.txt](./LICENSE.txt) file in this repository.
     * [tasks/](#tasks)
     * [utils/](#utils)
     * [static/](#static)
+    * [ecs](#ecs)
+    * [scripts](#scripts)
   * [Getting Started](#getting-started)
     * [Base Installation](#base-installation)
-      * [Setup: Pyenv](#setup-pyenv)
+      * [Setup: Pyenv and Pipenv](#setup-pyenv-and-pipenv)
       * [Setup: Nix](#setup-nix)
     * [Installing Python Dependencies and Pre-commit Hooks](#installing-python-dependencies-and-pre-commit-hooks)
     * [Unsupported Setup](#unsupported-setup)
@@ -50,14 +51,14 @@ the [LICENSE.txt](./LICENSE.txt) file in this repository.
     * [Deploying New Tests](#deploying-new-tests)
   * [Fake Data Generation](#fake-data-generation)
     * [Creating a custom parser](#creating-a-custom-parser)
-  * [Load Testing against AWS Loadtest Environment](#load-testing-against-aws-loatest-environment)
+  * [Load Testing against AWS Loadtest Environment](#load-testing-against-aws-loadtest-environment)
     * [Prime API](#prime-api)
     * [MilMove/Office domains](#milmoveoffice-domains)
     * [Handling Rate Limiting](#handling-rate-limiting)
     * [Metrics](#metrics)
   * [References](#references)
 
-<!-- Added by: felipe, at: Tue Oct 26 12:32:37 PDT 2021 -->
+<!-- Added by: felipe, at: Wed Nov 17 15:44:25 PST 2021 -->
 
 <!--te-->
 <!-- markdownlint-restore -->
@@ -254,12 +255,6 @@ local environment:
 ```shell script
 make db_dev_e2e_populate  ## populates the development database with test data
 make server_run
-```
-
-Back in `milmove_load_testing`, make sure you activate your virtual environment before attempting to run tests:
-
-```shell script
-pyenv activate locust-venv
 ```
 
 ### Setting up Tests in AWS

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ level of this repo and reload your shell.
   This will install all the `python` dependencies in `requirements.txt` and `requirements-dev.txt`. It will also install
   the `pre-commit` hooks.
 
-*Note: The requirements are indicated in the `Pipenv` file.
+*Note: The requirements are indicated in the `Pipfile`.
 
 ### Unsupported Setup
 

--- a/fresh-brew.local
+++ b/fresh-brew.local
@@ -2,9 +2,6 @@
 
 python_version="3.9.6"
 
-# This file is named a bit confusingly when using virtualenvs...
-venv_name="$(cat < ".python-version")"
-
 ##### START OF HELPER FUNCTIONS #####
 
 # If this breaks, you can look at the config instructions on their README
@@ -25,8 +22,6 @@ configure_shell_file_for_pyenv() {
 
   elif [[ $SHELL == *zsh ]]; then
     # shellcheck disable=SC2016
-    echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
-    # shellcheck disable=SC2016
     append_to_file "$shell_file" 'eval "$(pyenv init -)"'
 
   elif [[ $SHELL == *bash ]]; then
@@ -41,17 +36,6 @@ configure_shell_file_for_pyenv() {
   fi
 }
 
-# If this breaks, you can see the config instructions on their README
-# https://github.com/pyenv/pyenv-virtualenv#installing-with-homebrew-for-macos-users
-configure_shell_file_for_pyenv_virtualenv() {
-  if [[ $SHELL == *fish ]]; then
-    append_to_file "$shell_file" 'status --is-interactive; and source (pyenv virtualenv-init - | psub)'
-  else
-    # shellcheck disable=SC2016
-    append_to_file "$shell_file" 'eval "$(pyenv virtualenv-init -)"'
-  fi
-}
-
 install_python_with_pyenv() {
   fancy_echo "Installing python $python_version ..."
 
@@ -60,11 +44,6 @@ install_python_with_pyenv() {
   else
     pyenv install "$python_version"
   fi
-}
-
-create_virtualenv() {
-  fancy_echo "Setting up virtualenv"
-  pyenv virtualenv "$python_version" "$venv_name" || fancy_echo "Using existing $venv_name..."
 }
 
 # If direnv stops working, it might be because the setup commands changed.
@@ -100,7 +79,6 @@ if [ -f "Brewfile.local" ]; then
 fi
 
 configure_shell_file_for_pyenv
-configure_shell_file_for_pyenv_virtualenv
 
 # make sure that any functions that write to the shell file appear before this
 # direnv function below because the direnv line has to be at the very end of the
@@ -108,7 +86,6 @@ configure_shell_file_for_pyenv_virtualenv
 configure_shell_file_for_direnv
 
 install_python_with_pyenv
-create_virtualenv
 set_up_markdown_toc
 
 fancy_echo "******* IMPORTANT **************************************"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -32,6 +32,14 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
+      name = "pipenv-2021.5.29";
+      url = "https://github.com/NixOS/nixpkgs/";
+      ref = "refs/heads/nixpkgs-unstable";
+      rev = "fe296b79b4c803fec51410a987a11f077715a845";
+    }) {}).pipenv
+
+    (import (builtins.fetchGit {
+      # Descriptive name to make the store path easier to identify
       name = "pre-commit-2.15.0";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 120
+exclude = '''
+/(
+  scripts/gen-docs-index
+)
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,2 @@
 [tool.black]
 line-length = 120
-exclude = '''
-/(
-  scripts/gen-docs-index
-)
-'''

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-black>=19.3b0
-cryptography
-flake8
-pytest
-pytest-mock
-responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-requests>=2.22.0
-locust>=1
-Faker
-prance[osv,cli]==0.19.0

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -204,7 +204,7 @@ class PrimeDataStorageMixin:
             )
 
     def has_all_default_mto_ids(self) -> bool:
-        """ Boolean indicating that we have all the values we need for creating new MTOs. """
+        """Boolean indicating that we have all the values we need for creating new MTOs."""
         return self.default_mto_ids and all(self.default_mto_ids.values())
 
 

--- a/tasks/tests/test_office.py
+++ b/tasks/tests/test_office.py
@@ -14,7 +14,7 @@ class TestOfficeDataStorageMixin:
 
     @classmethod
     def setup_class(cls):
-        """ Define and initialize the classes that will be tested. """
+        """Define and initialize the classes that will be tested."""
 
         class OfficeStorage1(OfficeDataStorageMixin):
             DATA_LIST_MAX = 3
@@ -33,7 +33,7 @@ class TestOfficeDataStorageMixin:
         ],
     )
     def test_get_stored__random(self, object_key, object_id, test_store):
-        """ Test retrieving a random object from the local_store dictionary lists. """
+        """Test retrieving a random object from the local_store dictionary lists."""
         self.storage1.local_store[object_key] = test_store
 
         assert self.storage1.get_stored(object_key) in test_store.values()
@@ -48,14 +48,14 @@ class TestOfficeDataStorageMixin:
         ],
     )
     def test_get_stored__by_id(self, object_key, object_id, test_store):
-        """ Test retrieving a random object from the local_store dictionary lists. """
+        """Test retrieving a random object from the local_store dictionary lists."""
         self.storage1.local_store[object_key] = test_store
 
         assert self.storage1.get_stored(object_key, object_id) == test_store[object_id]
         assert self.storage2.get_stored(object_key, object_id) == test_store[object_id]
 
     def test_get_stored__empty(self):
-        """ Test the get_stored() method with an empty list of data. """
+        """Test the get_stored() method with an empty list of data."""
         self.storage1.local_store["empty_list"] = {}
 
         assert self.storage1.get_stored("empty_list") is None
@@ -68,7 +68,7 @@ class TestOfficeDataStorageMixin:
         ],
     )
     def test_add_stored__new_item(self, object_key, object_data, test_store):
-        """ Test retrieving a random object from the local_store dictionary lists. """
+        """Test retrieving a random object from the local_store dictionary lists."""
         self.storage1.local_store[object_key] = test_store
         self.storage1.add_stored(object_key, object_data)
 
@@ -81,7 +81,7 @@ class TestOfficeDataStorageMixin:
         ],
     )
     def test_add_stored__items_list(self, object_key, object_data, test_store):
-        """ Test retrieving a random object from the local_store dictionary lists. """
+        """Test retrieving a random object from the local_store dictionary lists."""
         self.storage1.local_store[object_key] = test_store
         self.storage1.add_stored(object_key, object_data)
 
@@ -95,7 +95,7 @@ class TestOfficeDataStorageMixin:
         ],
     )
     def test_add_stored__updates_existing(self, object_key, object_data, test_store):
-        """ Test retrieving a random object from the local_store dictionary lists. """
+        """Test retrieving a random object from the local_store dictionary lists."""
         self.storage1.local_store[object_key] = test_store
         self.storage1.add_stored(object_key, object_data)
 
@@ -108,7 +108,7 @@ class TestOfficeDataStorageMixin:
         ],
     )
     def test_add_stored__list_does_not_overwrite(self, object_key, object_data, test_store):
-        """ Test retrieving a random object from the local_store dictionary lists. """
+        """Test retrieving a random object from the local_store dictionary lists."""
         self.storage1.local_store[object_key] = test_store
         self.storage1.add_stored(object_key, object_data)
 
@@ -122,7 +122,7 @@ class TestOfficeDataStorageMixin:
         ],
     )
     def test_add_stored__max_capacity(self, object_key, object_data, test_store):
-        """ Test retrieving a random object from the local_store dictionary lists. """
+        """Test retrieving a random object from the local_store dictionary lists."""
         self.storage1.local_store[object_key] = test_store
         assert len(self.storage1.local_store[object_key]) == self.storage1.DATA_LIST_MAX
 

--- a/tasks/tests/test_prime.py
+++ b/tasks/tests/test_prime.py
@@ -17,7 +17,7 @@ class TestPrimeDataStorageMixin:
 
     @classmethod
     def setup_class(cls):
-        """ Define and initialize the classes that will be tested. """
+        """Define and initialize the classes that will be tested."""
 
         class PrimeStorage1(PrimeDataStorageMixin):
             DATA_LIST_MAX = 3
@@ -36,7 +36,7 @@ class TestPrimeDataStorageMixin:
         ],
     )
     def test_get_stored(self, object_key, test_store):
-        """ Test retrieving a random object from the local_store dictionary lists. """
+        """Test retrieving a random object from the local_store dictionary lists."""
         self.storage1.local_store[object_key] = test_store
 
         assert self.storage1.get_stored(object_key) in test_store
@@ -44,7 +44,7 @@ class TestPrimeDataStorageMixin:
         assert len(self.storage1.local_store[object_key]) == len(self.storage2.local_store[object_key])
 
     def test_get_stored__empty(self):
-        """ Test the get_stored() method with an empty list of data. """
+        """Test the get_stored() method with an empty list of data."""
         empty_list = "empty"
         self.storage1.local_store[empty_list] = []
 
@@ -59,7 +59,7 @@ class TestPrimeDataStorageMixin:
         ],
     )
     def test_get_stored_shipment_address(self, shipment_test_store):
-        """ Test the process of getting a random address from the MTO_SHIPMENT local store. """
+        """Test the process of getting a random address from the MTO_SHIPMENT local store."""
         self.storage1.local_store[MTO_SHIPMENT] = shipment_test_store
         field, address = self.storage1.get_stored_shipment_address()
 
@@ -76,7 +76,7 @@ class TestPrimeDataStorageMixin:
         ],
     )
     def test_get_stored_shipment_address__given_shipment(self, test_shipment):
-        """ Test the process of getting a random address from an MTO_SHIPMENT object passed in as an argument. """
+        """Test the process of getting a random address from an MTO_SHIPMENT object passed in as an argument."""
         test_shipment = {"pickupAddress": {"id": "1234"}, "destinationAddress": {"id": "5768"}}
         field, address = self.storage1.get_stored_shipment_address(test_shipment)
 
@@ -93,7 +93,7 @@ class TestPrimeDataStorageMixin:
         ],
     )
     def test_get_stored_shipment_address__none_found(self, test_store):
-        """ Test get_stored_shipment_address when there are no valid addresses. """
+        """Test get_stored_shipment_address when there are no valid addresses."""
         self.storage1.local_store[MTO_SHIPMENT] = test_store
         with pytest.raises(TypeError):
             _field, _address = self.storage1.get_stored_shipment_address()
@@ -110,7 +110,7 @@ class TestPrimeDataStorageMixin:
         ],
     )
     def test_add_stored(self, object_key, new_object, test_store):
-        """ Test adding an object to local storage. """
+        """Test adding an object to local storage."""
         self.storage1.local_store[object_key] = test_store
         self.storage1.add_stored(object_key, new_object)
 
@@ -119,7 +119,7 @@ class TestPrimeDataStorageMixin:
         assert len(self.storage1.local_store[object_key]) == len(self.storage2.local_store[object_key])
 
     def test_add_stored__list(self):
-        """ Test adding a list of objects to local storage. """
+        """Test adding a list of objects to local storage."""
         new_data = ["multiple", "new", "objects"]
         self.storage1.local_store[PAYMENT_REQUEST] = ["payment"]
         self.storage1.add_stored(PAYMENT_REQUEST, new_data)
@@ -140,7 +140,7 @@ class TestPrimeDataStorageMixin:
         ],
     )
     def test_update_stored(self, object_key, old_object, new_object, test_store):
-        """ Test updating an object that is already in the local storage. """
+        """Test updating an object that is already in the local storage."""
         self.storage1.local_store[object_key] = test_store
         self.storage1.update_stored(object_key, old_object, new_object)
 

--- a/utils/base.py
+++ b/utils/base.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 
 class ImplementationError(Exception):
-    """ Base exception when a util hasn't been implemented correctly. """
+    """Base exception when a util hasn't been implemented correctly."""
 
 
 class ValueEnum(Enum):
@@ -22,5 +22,5 @@ class ValueEnum(Enum):
 
     @classmethod
     def match(cls, value):
-        """ Returns the first literal that matches the value - throws an IndexError if not found. """
+        """Returns the first literal that matches the value - throws an IndexError if not found."""
         return [c for c in cls if c == value or c.value == value][0]

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -34,7 +34,7 @@ QUEUES = "queues"
 
 
 class DataType(ValueEnum):
-    """ Swagger data types that we expect to deal with. Uses camelcase in values to match. """
+    """Swagger data types that we expect to deal with. Uses camelcase in values to match."""
 
     FIRST_NAME = "firstName"
     LAST_NAME = "lastName"

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class MilMoveProvider(AddressProvider, DateProvider):
-    """ Faker Provider class for sending back customized MilMove data. """
+    """Faker Provider class for sending back customized MilMove data."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -111,7 +111,7 @@ class MilMoveProvider(AddressProvider, DateProvider):
 
 
 class MilMoveData:
-    """ Base class to return fake data to use in MilMove endpoints. """
+    """Base class to return fake data to use in MilMove endpoints."""
 
     def __init__(self):
         """
@@ -141,11 +141,11 @@ class MilMoveData:
         }
 
     def get_random_choice(self, choices):
-        """ Given a list of random choices, returns one of them. """
+        """Given a list of random choices, returns one of them."""
         return self.fake.random_element(choices)
 
     def get_fake_data_for_type(self, data_type, params=None):
-        """ Given a specific data type, returns faker data for that type (if a mapping exists). """
+        """Given a specific data type, returns faker data for that type (if a mapping exists)."""
         try:
             return self.data_types[data_type](*params)
         except KeyError:  # data_type isn't in dictionary

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -146,6 +146,8 @@ class MilMoveData:
 
     def get_fake_data_for_type(self, data_type, params=None):
         """Given a specific data type, returns faker data for that type (if a mapping exists)."""
+        if not params:
+            params = []
         try:
             return self.data_types[data_type](*params)
         except KeyError:  # data_type isn't in dictionary

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -29,6 +29,9 @@ class BaseAPIField:
         if not self.discriminator_values:
             self.discriminator_values = []
 
+        if not self.definition:
+            self.definition = {}
+
     def add_discriminator_value(self, value):
         """
         Adds a discriminator value to the current list of discriminator values on this field.

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -158,7 +158,7 @@ class ObjectField(BaseAPIField):
             self.object_fields = []
 
     def has_field(self, field_name: str):
-        """ Checks if this object contains a field with the provided name in its object_fields property. """
+        """Checks if this object contains a field with the provided name in its object_fields property."""
         return field_name in [f.name for f in self.object_fields]
 
     def add_field(self, field, unique=False):
@@ -273,7 +273,7 @@ class ObjectField(BaseAPIField):
 
     @staticmethod
     def skip_field(field, **kwargs):
-        """ Evaluate whether or not we should skip this field while generating fake data. """
+        """Evaluate whether or not we should skip this field while generating fake data."""
         # Check the discriminator above all (for polymorphic API data):
         if (d_value := kwargs.get("discriminator_value")) and not field.is_valid_discriminator(d_value):
             return True

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -233,12 +233,12 @@ class MilMoveHostMixin:
 
     @property
     def is_local(self):
-        """ Indicates if this user is using the local environment. """
+        """Indicates if this user is using the local environment."""
         return self.env == MilMoveEnv.LOCAL
 
     @property
     def is_deployed(self):
-        """ Indicates if this user is running in a deployed environment. """
+        """Indicates if this user is running in a deployed environment."""
         return self.env != MilMoveEnv.LOCAL
 
 

--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -385,7 +385,7 @@ class APIParser:
 
 
 class PrimeAPIParser(APIParser):
-    """ Parser class for the Prime API. """
+    """Parser class for the Prime API."""
 
     api_file = "https://raw.githubusercontent.com/transcom/mymove/master/swagger/prime.yaml"
 
@@ -442,7 +442,7 @@ class PrimeAPIParser(APIParser):
 
 
 class SupportAPIParser(PrimeAPIParser):
-    """ Parser class for the Support API. """
+    """Parser class for the Support API."""
 
     api_file = "https://raw.githubusercontent.com/transcom/mymove/master/swagger/support.yaml"
 
@@ -478,6 +478,6 @@ class SupportAPIParser(PrimeAPIParser):
 
 
 class GHCAPIParser(APIParser):
-    """ Parser class for the GHC API. """
+    """Parser class for the GHC API."""
 
     api_file = "https://raw.githubusercontent.com/transcom/mymove/master/swagger/ghc.yaml"

--- a/utils/tests/test_fake_data.py
+++ b/utils/tests/test_fake_data.py
@@ -12,11 +12,11 @@ from utils.fake_data import MilMoveProvider, MilMoveData
 
 
 class TestMilMoveProvider:
-    """ Tests the MilMoveProvide class and its methods. """
+    """Tests the MilMoveProvide class and its methods."""
 
     @classmethod
     def setup_class(cls):
-        """ Initialize the MilMoveProvide that will be tested. """
+        """Initialize the MilMoveProvide that will be tested."""
         cls.fake = Faker()
         cls.fake.add_provider(MilMoveProvider)
         cls.provider = MilMoveProvider(Generator())
@@ -106,11 +106,11 @@ class TestMilMoveProvider:
 
 
 class TestMilMoveData:
-    """ Tests the MilMoveData class and its methods. """
+    """Tests the MilMoveData class and its methods."""
 
     @classmethod
     def setup_class(cls):
-        """ Initialize the MilMoveData that will be tested. """
+        """Initialize the MilMoveData that will be tested."""
         cls.data = MilMoveData()
 
     def test_init(self):

--- a/utils/tests/test_fields.py
+++ b/utils/tests/test_fields.py
@@ -13,11 +13,11 @@ from utils.fake_data import MilMoveProvider, MilMoveData
 
 
 class TestBaseAPIField:
-    """ Tests the BaseAPIField class and its methods """
+    """Tests the BaseAPIField class and its methods"""
 
     @classmethod
     def setup_class(cls):
-        """ Initialize the BaseAPIField that will be tested. """
+        """Initialize the BaseAPIField that will be tested."""
         cls.field = BaseAPIField(DataType.STREET_ADDRESS, name="streetAddress")
         cls.faker = MilMoveData()
 
@@ -48,7 +48,7 @@ class TestBaseAPIField:
 class TestEnumField:
     @classmethod
     def setup_class(cls):
-        """ Initialize the EnumField that will be tested. """
+        """Initialize the EnumField that will be tested."""
         cls.options = ["PERMANENT_CHANGE_OF_STATION", "RETIREMENT", "SEPARATION", "GHC", "NTS"]
         cls.enum_field = EnumField(name="ordersType", options=cls.options)
         cls.faker = MilMoveData()
@@ -61,7 +61,7 @@ class TestEnumField:
 class TestArrayField:
     @classmethod
     def setup_class(cls):
-        """ Initialize the ArrayField that will be tested. """
+        """Initialize the ArrayField that will be tested."""
         items_field = BaseAPIField(data_type=DataType.PHONE, name="phoneNumber")
         cls.array_field = ArrayField(name="phoneNumbers", min_items=1, max_items=5, items_field=items_field)
         cls.faker = MilMoveData()
@@ -76,11 +76,11 @@ class TestArrayField:
 
 
 class TestObjectField:
-    """ Tests the ObjectField class and its methods. """
+    """Tests the ObjectField class and its methods."""
 
     @classmethod
     def setup_class(cls):
-        """ Initialize the ObjectField that will be tested. """
+        """Initialize the ObjectField that will be tested."""
         cls.object_field = ObjectField(name="objectField")
         cls.faker = MilMoveData()
 
@@ -97,7 +97,7 @@ class TestObjectField:
         assert self.object_field.required is False
 
     def test_add_field(self):
-        """ Tests adding one field to the ObjectField instance's list of sub-fields. """
+        """Tests adding one field to the ObjectField instance's list of sub-fields."""
         self.object_field.object_fields = []
 
         test_field = BaseAPIField(name="baseField", data_type=DataType.INTEGER)
@@ -126,7 +126,7 @@ class TestObjectField:
         assert test_object in self.object_field.object_fields
 
     def test_add_fields(self):
-        """ Tests adding multiple fields at once to the the ObjectField's list of sub-fields. Calls add_field. """
+        """Tests adding multiple fields at once to the the ObjectField's list of sub-fields. Calls add_field."""
         self.object_field.object_fields = []
 
         field_list = [
@@ -180,7 +180,7 @@ class TestObjectField:
             self.object_field.combine_fields("field string")
 
     def test_get_field(self):
-        """ Tests retrieving a given field, by name, from this ObjectField's list of sub-fields. """
+        """Tests retrieving a given field, by name, from this ObjectField's list of sub-fields."""
         self.object_field.object_fields = []
 
         base_field = BaseAPIField(name="baseField", data_type=DataType.INTEGER)
@@ -189,7 +189,7 @@ class TestObjectField:
         assert returned_field == base_field
 
     def test_update_required_fields(self):
-        """ Tests updating a list of fields to be 'required' """
+        """Tests updating a list of fields to be 'required'"""
         self.object_field.object_fields = []
 
         base_field = BaseAPIField(name="baseField", data_type=DataType.INTEGER)
@@ -212,7 +212,7 @@ class TestObjectField:
         assert space_field.required is True
 
     def test_add_discriminator_value(self):
-        """ Tests adding a discriminator for sub-fields. """
+        """Tests adding a discriminator for sub-fields."""
         # Using the four fields set previous in test_update_required_fields
         assert len(self.object_field.object_fields) > 0
 
@@ -260,7 +260,7 @@ class TestObjectField:
 
 
 class TestObjectFieldFaker:
-    """ Tests the ObjectField class' `generate_fake_data` method. """
+    """Tests the ObjectField class' `generate_fake_data` method."""
 
     MOCK_FAKE_DATA = {
         DataType.INTEGER: 112358,
@@ -274,7 +274,7 @@ class TestObjectFieldFaker:
 
     @classmethod
     def setup_class(cls):
-        """ Init and setup the ObjectField for our fake data generation tests. """
+        """Init and setup the ObjectField for our fake data generation tests."""
         cls.faker = MilMoveData()
         cls.object_field = ObjectField(name="objectField")
 

--- a/utils/tests/test_fields.py
+++ b/utils/tests/test_fields.py
@@ -330,7 +330,7 @@ class TestObjectFieldFaker:
         def mock_get_random_choice(_, choices):
             return choices[0] if choices else None
 
-        def mock_get_fake_data_for_type(_, data_type):
+        def mock_get_fake_data_for_type(_, data_type, params=None):
             return TestObjectFieldFaker.MOCK_FAKE_DATA[data_type]
 
         mocker.patch.object(MilMoveData, "get_random_choice", mock_get_random_choice)
@@ -345,8 +345,10 @@ class TestObjectFieldFaker:
         """
         self.setup_mocks(mocker)
 
+        fake_data = self.object_field.generate_fake_data(self.faker)
+
         # require_all=False, so we should only see required fields:
-        assert self.object_field.generate_fake_data(self.faker) == {
+        assert fake_data == {
             "objectArray": [
                 {"integer": self.MOCK_FAKE_DATA[DataType.INTEGER]},
                 {"integer": self.MOCK_FAKE_DATA[DataType.INTEGER]},

--- a/utils/tests/test_hosts.py
+++ b/utils/tests/test_hosts.py
@@ -19,7 +19,7 @@ class TestMilMoveDomain:
         assert (
             MilMoveDomain.match(MilMoveDomain.PRIME).host_name("local", True, 1111, "http") == "http://primelocal:1111"
         )
-        assert MilMoveDomain.match(MilMoveDomain.PRIME).host_name("exp") == "https://prime.exp.move.mil"
+        assert MilMoveDomain.match(MilMoveDomain.PRIME).host_name("exp") == "https://prime.loadtest.dp3.us"
 
         with pytest.raises(ImplementationError):
             MilMoveDomain.match(MilMoveDomain.PRIME).host_name("local", True, 11111)
@@ -83,8 +83,8 @@ class TestMilMoveHostMixin:
         assert self.TestUser2.host is None
 
         self.TestUser1.set_host_name()
-        assert self.TestUser1.host == "https://api.exp.move.mil"
-        assert self.TestUser2.host == "https://api.exp.move.mil"
+        assert self.TestUser1.host == "https://api.loadtest.dp3.us"
+        assert self.TestUser2.host == "https://api.loadtest.dp3.us"
 
     @mock.patch.dict(os.environ, {"MOVE_MIL_EXP_TLS_CERT": "test_cert", "MOVE_MIL_EXP_TLS_KEY": "test_key"})
     def test_set_cert_kwargs(self):
@@ -151,6 +151,7 @@ def test_clean_milmove_host_users(mocker):
         is_api = True
         host = "exp"
         tasks = {}
+        weight = 1
 
     env = Environment(user_classes=[MockUser])
     TestUser = MockUser()

--- a/utils/tests/test_hosts.py
+++ b/utils/tests/test_hosts.py
@@ -13,7 +13,7 @@ from utils.base import ImplementationError
 
 
 class TestMilMoveDomain:
-    """ Tests the MilMoveDomain class and its methods. """
+    """Tests the MilMoveDomain class and its methods."""
 
     def test_host_name(self):
         assert (
@@ -29,11 +29,11 @@ class TestMilMoveDomain:
 
 
 class TestMilMoveHostMixin:
-    """ Tests the MilMoveHostMixin class and its methods. """
+    """Tests the MilMoveHostMixin class and its methods."""
 
     @classmethod
     def setup_class(cls):
-        """ Define and initialize classes to be tested """
+        """Define and initialize classes to be tested"""
 
         class HostUser(MilMoveHostMixin):
             # These attributes are used in MilMoveHostMixin to set up the proper hostname for any MilMove environment:

--- a/utils/tests/test_parsers.py
+++ b/utils/tests/test_parsers.py
@@ -208,15 +208,15 @@ class TestAPIParser:
     @pytest.mark.parametrize(
         "typed_field_args,expected_type",
         [
-            (("firstName", "string", ""), DataType.FIRST_NAME),
-            (("postalCode", "string", "zip"), DataType.POSTAL_CODE),
-            (("contact", "string", "email"), DataType.EMAIL),
-            (("bestDateForDancing", "string", "date-time"), DataType.DATE_TIME),
-            (("randomThought", "string", ""), DataType.SENTENCE),
-            (("numRandomThoughts", "integer", ""), DataType.INTEGER),
-            (("numRandomThoughts", "integer", ""), DataType.INTEGER),
-            (("randomThing", "badType", "badFormat"), None),
-            (("", "", ""), None),
+            (("firstName", "string", "", None), DataType.FIRST_NAME),
+            (("postalCode", "string", "zip", None), DataType.POSTAL_CODE),
+            (("contact", "string", "email", None), DataType.EMAIL),
+            (("bestDateForDancing", "string", "date-time", None), DataType.DATE_TIME),
+            (("randomThought", "string", "", None), DataType.SENTENCE),
+            (("numRandomThoughts", "integer", "", None), DataType.INTEGER),
+            (("numRandomThoughts", "integer", "", None), DataType.INTEGER),
+            (("randomThing", "badType", "badFormat", None), None),
+            (("", "", "", None), None),
         ],
     )
     def test__parse_typed_field(self, typed_field_args, expected_type):

--- a/utils/tests/test_parsers.py
+++ b/utils/tests/test_parsers.py
@@ -15,13 +15,13 @@ from .params_parsers import *
 
 
 class TestAPIParser:
-    """ Tests the APIParser class and its methods. """
+    """Tests the APIParser class and its methods."""
 
     TEST_API = os.path.join(STATIC_FILES, "test_api.yaml")
 
     @classmethod
     def setup_class(cls):
-        """ Initialize the APIParser that will be tested. """
+        """Initialize the APIParser that will be tested."""
         cls.parser = APIParser(api_file=cls.TEST_API)
 
     def test_init(self):
@@ -145,7 +145,7 @@ class TestAPIParser:
         ],
     )
     def test__parse_definition(self, name, definition, expected_type):
-        """ Tests that _parse_definition returns the correct field type. """
+        """Tests that _parse_definition returns the correct field type."""
         field = self.parser._parse_definition(name, definition)
 
         assert field is not None
@@ -161,7 +161,7 @@ class TestAPIParser:
         ],
     )
     def test__parse_object_field(self, object_name, object_def, num_fields_expected):
-        """ Tests that an ObjectField with the correct properties is returned. """
+        """Tests that an ObjectField with the correct properties is returned."""
         field = self.parser._parse_object_field(object_name, object_def)
 
         assert field.name == object_name
@@ -169,7 +169,7 @@ class TestAPIParser:
         assert len(field.object_fields) == num_fields_expected
 
     def test__parse_discriminator(self):
-        """ Tests that a polymorphic API definition is parsed correctly. """
+        """Tests that a polymorphic API definition is parsed correctly."""
         object_field = ObjectField(name="trees")
         object_field = self.parser._parse_discriminator(object_field, TREE_DEF)
 
@@ -195,7 +195,7 @@ class TestAPIParser:
         "array_name,array_def", [("AppleTrees", APPLE_TREES_DEF), ("trees", ORCHARD_DEF["properties"]["trees"])]
     )
     def test__parse_array_field(self, array_name, array_def):
-        """ Tests that the correct ArrayField object is returned from _parse_array_field. """
+        """Tests that the correct ArrayField object is returned from _parse_array_field."""
         array_field = self.parser._parse_array_field(array_name, array_def)
 
         assert array_field is not None
@@ -220,7 +220,7 @@ class TestAPIParser:
         ],
     )
     def test__parse_typed_field(self, typed_field_args, expected_type):
-        """ Tests that the correct BaseAPIField is generated for a given field name, type, and format. """
+        """Tests that the correct BaseAPIField is generated for a given field name, type, and format."""
         if not expected_type:
             assert self.parser._parse_typed_field(*typed_field_args) is None
             return  # done with this test
@@ -244,16 +244,16 @@ class TestAPIParser:
         ],
     )
     def test__approximate_str_type(self, field_name, expected_type):
-        """ Test that field names are being used to approximate the closest data type. """
+        """Test that field names are being used to approximate the closest data type."""
         assert self.parser._approximate_str_type(field_name) == expected_type
 
 
 class TestPrimeAPIParser:
-    """ Tests some of the custom methods on the PrimeAPIParser class """
+    """Tests some of the custom methods on the PrimeAPIParser class"""
 
     @classmethod
     def setup_class(cls):
-        """ Initialize the APIParser that will be tested. """
+        """Initialize the APIParser that will be tested."""
         cls.parser = PrimeAPIParser()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Pipenv lets us manage dependencies and creates a lock file so we can have reproducible builds.

In addition, `direnv` supports it natively and will install the dependencies and manage the virtualenv for us.

I also took the opportunity to get the pre-commit in sync with the dependencies and use a `pyproject.toml`

Finally, I fixed the tests and enabled them in CI

## Reviewer Notes

I've tested this out with nix and as much as I can with brew, although I don't use it extensively, so any validation you all can do would be great

## Setup

Check out the code and try to follow the README to get your environment set up

