### PR TITLE
MB-10536 Add starting point for customer seed data for prime

### DIFF
--- a/locustfiles/prime.py
+++ b/locustfiles/prime.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 """ Locust test for the Prime & Support APIs """
 from locust import HttpUser, between, events
+from utils.constants import INTERNAL_API_KEY, PRIME_API_KEY
 
 from utils.hosts import MilMoveHostMixin, MilMoveDomain, clean_milmove_host_users
-from utils.parsers import PrimeAPIParser, SupportAPIParser
+from utils.parsers import InternalAPIParser, PrimeAPIParser, SupportAPIParser
 from tasks import PrimeTasks, SupportTasks
 
 # init these classes just once because we don't need to parse the API over and over:
 prime_api = PrimeAPIParser()
 support_api = SupportAPIParser()
+internal_api = InternalAPIParser()
 
 
 class PrimeUser(MilMoveHostMixin, HttpUser):
@@ -22,7 +24,7 @@ class PrimeUser(MilMoveHostMixin, HttpUser):
     is_api = True  # if True, uses the api base domain in deployed environments
 
     # This attribute is used for generating fake requests when hitting the Prime API:
-    parser = prime_api
+    parser = {PRIME_API_KEY: prime_api, INTERNAL_API_KEY: internal_api}
 
     # These are locust HttpUser attributes that help define and shape the load test:
     wait_time = between(0.25, 9)  # the time period to wait in between tasks (in seconds, accepts decimals and 0)

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -267,7 +267,6 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         payload = self.fake_request(
             "/service_members/{serviceMemberId}/backup_contacts", "post", INTERNAL_API_KEY, overrides
         )
-        print(payload)
         self.client.post(
             self.customer_path(f"/internal/service_members/{service_member_id}/backup_contacts"),
             name="/internal/service_members/{serviceMemberId}/backup_contacts",

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -16,6 +16,7 @@ LOCAL_TLS_CERT_KWARGS = {"cert": (LOCAL_MTLS_CERT, LOCAL_MTLS_KEY), "verify": Fa
 
 PRIME_API_KEY = "prime"
 SUPPORT_API_KEY = "support"
+INTERNAL_API_KEY = "internal"
 
 ARRAY_MIN = 1
 ARRAY_MAX = 5
@@ -37,7 +38,9 @@ class DataType(ValueEnum):
     """Swagger data types that we expect to deal with. Uses camelcase in values to match."""
 
     FIRST_NAME = "firstName"
+    FIRST_NAME_VARIANT = "first_name"  # matches older swagger format
     LAST_NAME = "lastName"
+    LAST_NAME_VARIANT = "last_name"  # matches older swagger format
     PHONE = "phone"
     EMAIL = "email"
     STREET_ADDRESS = "streetAddress"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -35,7 +35,9 @@ QUEUES = "queues"
 
 
 class DataType(ValueEnum):
-    """Swagger data types that we expect to deal with. Uses camelcase in values to match."""
+    """
+    Swagger data types that we expect to deal with. The latest pattern uses camelCase, while the older pattern uses snake_case.
+    """
 
     FIRST_NAME = "firstName"
     FIRST_NAME_VARIANT = "first_name"  # matches older swagger format

--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -121,7 +121,9 @@ class MilMoveData:
         self.fake.add_provider(MilMoveProvider)
         self.data_types = {
             DataType.FIRST_NAME: self.fake.safe_first_name,
+            DataType.FIRST_NAME_VARIANT: self.fake.safe_first_name,
             DataType.LAST_NAME: self.fake.safe_last_name,
+            DataType.LAST_NAME_VARIANT: self.fake.safe_last_name,
             DataType.PHONE: self.fake.safe_phone_number,
             DataType.EMAIL: self.fake.safe_email,
             DataType.STREET_ADDRESS: self.fake.safe_street_address,

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -90,6 +90,9 @@ class MilMoveHostMixin:
     # {"cert": <cert/key file path(s)>, "verify": <False or the CA bundle file path>}
     cert_kwargs: Optional[dict] = None
 
+    # domain name for the MILMOVE/customer portion of the app
+    alternative_host = None
+
     def __init__(self, *args, **kwargs):
         """
         Sets the Users' host based on environment value from --host flag in command. Note that the self.host value is
@@ -140,6 +143,7 @@ class MilMoveHostMixin:
             cls.host = MilMoveDomain.match(cls.domain).host_name(
                 cls.env.value, cls.is_api, cls.local_port, cls.local_protocol
             )
+            cls.alternative_host = MilMoveDomain.MILMOVE.host_name(cls.env.value, False, "8080", "http")
         except IndexError:  # means MilMoveDomain could not find a match for the value passed in
             logger.debug(f"Bad domain value: {cls.domain}")
             raise ImplementationError("Domain for MilMoveHostMixin must match one of the values in MilMoveDomain.")

--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -481,3 +481,9 @@ class GHCAPIParser(APIParser):
     """Parser class for the GHC API."""
 
     api_file = "https://raw.githubusercontent.com/transcom/mymove/master/swagger/ghc.yaml"
+
+
+class InternalAPIParser(APIParser):
+    """Parser class for the Internal API."""
+
+    api_file = "https://raw.githubusercontent.com/transcom/mymove/master/swagger/internal.yaml"


### PR DESCRIPTION
## Description

This adds a starting point for initializing seed data within the `prime.py` locust test flow. For each user we are logging into dev-local and attempting to go through the entire customer flow. Right now these changes just create the user and adds all of the information needed to setup their profile.

Note: Some of this code should be refactored if it is being used in other tests. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
locust -f locustfiles/prime.py --host local
```

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-10536) for this change.
