### PR TITLE
MB-10652 create shipment

### DIFF
--- a/tasks/base.py
+++ b/tasks/base.py
@@ -10,7 +10,7 @@ from requests import Response
 logger = logging.getLogger(__name__)
 
 
-def check_response(response: Response, task_name="Task", request=None, expected_status_code: str = None):
+def check_response(response: Response, task_name="Task", request=None, expected_status_code: str = "2"):
     """
     Logs the status code from the response and converts it from JSON into a python dictionary we can work with. If the
     status code doesn't match (by default 2xx), it can also log any request data that was sent in for the sake of debugging.
@@ -29,9 +29,6 @@ def check_response(response: Response, task_name="Task", request=None, expected_
     except (json.JSONDecodeError, TypeError):
         logger.exception("Non-JSON response.")
         return None, False
-
-    if expected_status_code is None:
-        expected_status_code = "2"
 
     if not str(response.status_code).startswith(expected_status_code):
         logger.error(f"⚠️ {task_name} failed.\n{json.dumps(json_response, indent=4)}")

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -10,15 +10,16 @@ from requests import Response
 logger = logging.getLogger(__name__)
 
 
-def check_response(response: Response, task_name="Task", request=None):
+def check_response(response: Response, task_name="Task", request=None, expected_status_code: str = None):
     """
     Logs the status code from the response and converts it from JSON into a python dictionary we can work with. If the
-    status code wasn't a success (2xx), it can also log any request data that was sent in for the sake of debugging.
+    status code doesn't match (by default 2xx), it can also log any request data that was sent in for the sake of debugging.
     Returns the dictionary representation of the response content and a boolean indicating success or failure.
 
     :param response: HTTP Response class from the Python requests framework
     :param task_name: str, optional name of the tasks
     :param request: any type, optional data to print for debugging a failed response
+    :param expected_status_code: str, expected code of response if no value is provided expects 2xx
     :return: tuple(dict, bool)
     """
     logger.info(f"ℹ️ {task_name} status code: {response.status_code} {response.reason}")
@@ -29,7 +30,10 @@ def check_response(response: Response, task_name="Task", request=None):
         logger.exception("Non-JSON response.")
         return None, False
 
-    if not str(response.status_code).startswith("2"):
+    if expected_status_code is None:
+        expected_status_code = "2"
+
+    if not str(response.status_code).startswith(expected_status_code):
         logger.error(f"⚠️ {task_name} failed.\n{json.dumps(json_response, indent=4)}")
         if request:
             try:

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -544,8 +544,11 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         if mto_shipment.get("agents") is None:
             return  # can't update agents if there aren't any
 
+        overrides = {}
+        mto_agents = mto_shipment["agents"]
         mto_agent = mto_shipment["agents"][0]
-        overrides = {"agentType": mto_agent["agentType"]}  # updates the agent, but keeps the same agent type
+        if len(mto_agents) >= 2:
+            overrides = {"agentType": mto_agent["agentType"]}  # ensure agentType does not change
         payload = self.fake_request("/mto-shipments/{mtoShipmentID}/agents/{agentID}", "put", PRIME_API_KEY, overrides)
         headers = {"content-type": "application/json", "If-Match": mto_agent["eTag"]}
         resp = self.client.put(

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -356,7 +356,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         if overrides:
             overrides_local.update(overrides)
         payload = self.fake_request("/mto-shipments", "post", PRIME_API_KEY, overrides=overrides_local)
-        guarantee_unique_agent_type(payload["agents"])
+        guarantee_unique_agent_type(payload["agents"])  # modifies the payload directly
 
         headers = {"content-type": "application/json"}
         resp = self.client.post(

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -544,8 +544,9 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         if mto_shipment.get("agents") is None:
             return  # can't update agents if there aren't any
 
-        payload = self.fake_request("/mto-shipments/{mtoShipmentID}/agents/{agentID}", "put", PRIME_API_KEY)
         mto_agent = mto_shipment["agents"][0]
+        overrides = {"agentType": mto_agent["agentType"]}  # updates the agent, but keeps the same agent type
+        payload = self.fake_request("/mto-shipments/{mtoShipmentID}/agents/{agentID}", "put", PRIME_API_KEY, overrides)
         headers = {"content-type": "application/json", "If-Match": mto_agent["eTag"]}
         resp = self.client.put(
             prime_path(f"/mto-shipments/{mto_shipment['id']}/agents/{mto_agent['id']}"),

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -409,7 +409,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             headers=headers,
             **self.user.cert_kwargs,
         )
-        check_response(resp, "createMTOShipment", payload)
+        check_response(resp, "createMTOShipmentFailure", payload, "422")
 
     @tag(PAYMENT_REQUEST, "createUpload")
     @task

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -377,7 +377,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
 
         move_task_order = self.get_stored(MOVE_TASK_ORDER, object_id)
         if not move_task_order:
-            logger.debug("createMTOShipment: ⚠️ No move_task_order found")
+            logger.debug("createMTOShipment — expected failure: ⚠️ No move_task_order found")
             return (
                 None  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
             )

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -382,7 +382,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
                 None  # we can't do anything else without a default value, and no pre-made MTOs satisfy our requirements
             )
 
-        agent_type = random.sample(["RELEASING_AGENT", "RECEIVING_AGENT"], 1).pop()
+        agent_type = random.choice(["RELEASING_AGENT", "RECEIVING_AGENT"])
         agent_override = {"id": ZERO_UUID, "mtoShipmentID": ZERO_UUID, "agentType": agent_type}
         overrides_local = {
             # Override moveTaskorderID because we don't want a random one

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -765,11 +765,11 @@ class SupportTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSe
 
         resp = self.client.patch(
             support_path(f"/mto-shipments/{mto_shipment['id']}/status"),
-            name=support_path("/mto-shipments/{mtoShipmentID}/status -- expected failure"),
+            name=support_path("/mto-shipments/{mtoShipmentID}/status — expected failure"),
             data=json.dumps(payload),
             headers=headers,
         )
-        check_response(resp, "updateMTOShipmentStatusFailure", payload)
+        check_response(resp, "updateMTOShipmentStatusFailure", payload, "422")
 
     @tag(MOVE_TASK_ORDER, "createMoveTaskOrder")
     @task(2)


### PR DESCRIPTION
## Description

This fixes tests for creating an MTO shipment when multiple agents have the same type. This also adds a tests for an intentional failure, for having multiple agents of the same type.

![image](https://user-images.githubusercontent.com/84742904/146072734-e5794b41-d5b4-4877-bc8f-c46ee22afc97.png)

## Reviewer Notes

Do we want to maintain logging for expected failure cases? Using the `check_response` helper method causes the output in the terminal to be verbose. When we have an error check_response logs the entire json payload which in this case is ~45 lines.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make load_test_prime
```

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-10652) for this change.
