### PR TITLE
[MB-10562] Create dependabot config for pipenv and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # pipenv requires using the "pip" value https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+  # The python version base image is the only real docker dependency but should match what's in the pipfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies


### PR DESCRIPTION
## Description

This PR creates a dependabot config in `.github/dependabot.yml` to run daily at 11:00 (the same as mymove) for both the pipenv dependencies and the docker dependency.

I will need to update the [dependencies documentation](https://dp3.atlassian.net/wiki/spaces/MT/pages/1419870254/Dependency+Updates+Process+Working+Document) to make sure these are taken care of with the others.  Since GitHub acquired Dependabot I noticed some [broken links in the mymove-docs repo](https://transcom.github.io/mymove-docs/docs/tools/dependabot/manage-dependabot) too redirected to the wrong places.

Once merged we can manage dependabot from the insights -> dependency graph -> dependabot page https://github.com/transcom/milmove_load_testing/network/updates

[Dependabot configuration options](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates)

[mymove Dependabot reference file](https://github.com/transcom/mymove/blob/master/.github/dependabot.yml)

## Reviewer Notes

I don't think this is a PR that can be tested until it's merged.

We may decide to add base versions in our pipfile instead of wildcards for some dependencies.

I can't remember how we settled on the current python version but I could see us turning off the docker checks so it doesn't get out of line with pipenv.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-10562) for this change.
