### PR TITLE
Mb 10647 rp create moves

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -260,7 +260,6 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             name="/internal/service_members/{serviceMemberId}",
             data=json.dumps(payload),
             headers={"content-type": "application/json"},
-            **self.user.cert_kwargs,
         )
 
         overrides = {"permission": "NONE"}
@@ -272,7 +271,6 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             name="/internal/service_members/{serviceMemberId}/backup_contacts",
             data=json.dumps(payload),
             headers={"content-type": "application/json"},
-            **self.user.cert_kwargs,
         )
 
     @tag(MOVE_TASK_ORDER, "listMoves")

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -293,7 +293,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         payload = self.fake_request("/orders", "post", INTERNAL_API_KEY, overrides, True)
         order_resp = self.client.post(
             self.customer_path("/internal/orders"),
-            data=json.dumps(overrides),
+            data=json.dumps(payload),
             headers={"content-type": "application/json"},
         )
         order = order_resp.json()

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -155,13 +155,11 @@ class PrimeDataStorageMixin:
         if self.has_all_default_mto_ids():
             return
 
-        headers = {"content-type": "application/json"}
-
         # Call the Support API to get full details on the move:
         resp = self.client.get(
             support_path(f"/move-task-orders/{move_id}"),
             name=support_path("/move-task-orders/{moveTaskOrderID}"),
-            headers=headers,
+            headers={"content-type": "application/json"},
             **self.cert_kwargs,
         )
         move_details, success = check_response(resp, "getMoveTaskOrder")
@@ -180,24 +178,6 @@ class PrimeDataStorageMixin:
             )
             self.default_mto_ids["originDutyStationID"] = order_details.get(
                 "originDutyStationID", self.default_mto_ids["originDutyStationID"]
-            )
-
-        # Do we have all the ID values we need? Cool, then stop processing.
-        if self.has_all_default_mto_ids():
-            logger.info(f"☑️ Set default MTO IDs for createMoveTaskOrder: \n{self.default_mto_ids}")
-            return
-
-        # If we're in the local environment, and we have gone through the entire list without getting a full set of IDs,
-        # set our hardcoded IDs as the default:
-        if not self.has_all_default_mto_ids() and self.user.is_local:
-            logger.warning("⚠️ Using hardcoded MTO IDs for LOCAL env")
-            self.default_mto_ids.update(
-                {
-                    "contractorID": "5db13bb4-6d29-4bdb-bc81-262f4513ecf6",
-                    "destinationDutyStationID": "71b2cafd-7396-4265-8225-ff82be863e01",
-                    "originDutyStationID": "1347d7f3-2f9a-44df-b3a5-63941dd55b34",
-                    "uploadedOrdersID": "c26421b0-e4c3-446b-88f3-493bb25c1756",
-                }
             )
 
     def has_all_default_mto_ids(self) -> bool:

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -282,7 +282,6 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             "issue_date": datetime.now().strftime("%Y-%m-%d"),
             "report_by_date": datetime.now().strftime("%Y-%m-%d"),
             "orders_type": "PERMANENT_CHANGE_OF_STATION",
-            "orders_type_detail": "HHG_PERMITTED",
             "has_dependents": False,
             "spouse_has_pro_gear": False,
             "new_duty_station_id": stations[1]["id"],

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -225,6 +225,7 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         return f"{self.user.alternative_host}{url}"
 
     def on_start(self):
+        # Customer login using dev local
         self.client.get(self.customer_path("/devlocal-auth/login"))
         self.csrf_token = self.client.cookies.get("masked_gorilla_csrf")
         self.client.headers.update({"x-csrf-token": self.csrf_token})
@@ -242,8 +243,10 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
         email = json_resp["email"]
         user_id = json_resp["id"]
 
-        origin_duty_stations = self.client.get(self.customer_path("/internal/duty_stations?search=29"))
-        current_station_id = origin_duty_stations.json()[0]["id"]
+        # Setup customer profile
+        duty_stations = self.client.get(self.customer_path("/internal/duty_stations?search=palms"))
+        stations = duty_stations.json()
+        current_station_id = stations[0]["id"]
 
         overrides = {
             "id": service_member_id,

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -332,6 +332,24 @@ class PrimeTasks(PrimeDataStorageMixin, ParserTaskMixin, CertTaskMixin, TaskSet)
             headers={"content-type": "application/json"},
         )
 
+        # Confirm move request
+        full_name = f"{service_member['first_name']} {service_member['last_name']}"
+        overrides = {
+            "certification_type": "SHIPMENT",
+            "signature": full_name,
+            "date": datetime.now().strftime(
+                "%Y-%m-%dT%H:%M:%S-05:00"
+            ),  # needed because yaml uses date instead of date-time
+            "personally_procured_move_id": None,
+        }
+        payload = self.fake_request("/moves/{moveId}/submit", "post", INTERNAL_API_KEY, overrides, True)
+        self.client.post(
+            self.customer_path(f"/internal/moves/{move_id}/submit"),
+            name="/internal/moves/{moveId}/submit",
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+
     @tag(MOVE_TASK_ORDER, "listMoves")
     @task
     def list_moves(self):

--- a/tasks/tests/test_prime.py
+++ b/tasks/tests/test_prime.py
@@ -244,11 +244,14 @@ class TestPrimeDataStorageMixin:
         # Random list to use after first run, none of these values will be used after the default IDs are initially set:
         test_moves_after = [
             {
-                "contractorID": "contractor4",
-                "order": {
-                    "uploadedOrdersID": "upload4",
-                    "destinationDutyStationID": "destination4",
-                    "originDutyStationID": "origin4",
+                "id": "101",
+                "status": 200,
+                "json": {
+                    "order": {
+                        "uploadedOrdersID": "upload101",
+                        "destinationDutyStationID": "destination101",
+                        "originDutyStationID": "origin101",
+                    },
                 },
             }
         ]
@@ -257,14 +260,16 @@ class TestPrimeDataStorageMixin:
         session_storage1 = PrimeSessionStorage1()
         session_storage2 = PrimeSessionStorage2()
 
-        session_storage1.set_default_mto_ids(test_moves)
+        for move in test_moves:
+            session_storage1.set_default_mto_ids(move["id"])
 
         assert session_storage1.default_mto_ids == expected_ids
         assert session_storage1.default_mto_ids == session_storage2.default_mto_ids
         assert len(responses.calls) == 4
 
         # Call func again with new list, but all values should stay the same as before:
-        session_storage2.set_default_mto_ids(test_moves_after)
+        for move in test_moves_after:
+            session_storage2.set_default_mto_ids(move["id"])
 
         assert session_storage1.default_mto_ids == expected_ids
         assert session_storage1.default_mto_ids == session_storage2.default_mto_ids


### PR DESCRIPTION
## Description

Adds move setup as part of the prime load tests.

## Reviewer Notes

The code is a giant block of code at the moment and likely will be worthwhile to separate out where the comments are made for each distinct step. I have tentatively refrained from doing this because there are some potential changes with how/where this will be used in [Felipe's PR](https://github.com/transcom/milmove_load_testing/pull/97) and the unknowns of how and if these functions will be used by other tests. In addition to those reason, we are also utilizing some of the data from previous steps so this will require some level of data management / parameters to refactor.

## Setup

When running the prime load tests using
```sh
make load_test_prime
```
you should be able to log into the the most recently created user to see that they have successfully created and submitted a move. (If you don't have a clean DB you can optinally add `print(email)` to the end of the  `on_start` function to see the email and login using that email to verify.

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-10647) for this change.
