### PR TITLE
update dockerfile build to use pipfile.lock, sync black pre-commit ve…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/ambv/black
-    rev: 21.10b0
+    rev: 21.12b0
     hooks:
       - id: black
         language_version: python3.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir pipenv==2021.5.29
 # outside of virtualenv
 COPY Pipfile Pipfile.lock /app/
 RUN set -x \
-    && pipenv install --system --deploy --site-packages \
+    && pipenv install --system --deploy --site-packages --ignore-pipfile \
     && rm -rf /root/.local/share/virtualenv /root/.local/share/virtualenvs
 
 # Copy over everything else for the app:

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ zipcodes = "*"
 
 [dev-packages]
 # pipenv doesn't resolve pre-release versions, so manually pin
+# this version should match what is in .pre-commit-config.yaml as well
 black = "==21.12b0"
 flake8 = "*"
 pytest = "*"


### PR DESCRIPTION
## Description

When trying to deploy a new version of this repo to AWS through CodeBuild, it was failing during the build of the Dockerfile due to trying to install newer versions of libraries in our Pipfile.

When we migrated to using pipfile.lock for CircleCI, which uses `pipenv sync`, we didn't adjust our Dockerfile `pipenv install` step to use the pipfile.lock instead of using the pipfile that contains wildcards.

I also updated the pre-commit version of black to the one upgraded previously by dependabot.

## Reviewer Notes

I'll test this out in AWS with a new Codebuild deploy to verify that the Dockerfile builds properly.

## Setup

Login to the AWS console using the dev credentials from the transcom-infrasec-gov-nonato repo.

```sh
aws-vault login transcom-gov-dev
```

1. In the AWS console, select the CodeBuild service and select the milmove_load_testing project.
2. Start a new build with overrides and post this branch name or PR as the source to use.
3. Wait for the build logs to succeed without error.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change.
* [This article](tbd) explains more about the approach used.

## Screenshots

<img width="1144" alt="Screen Shot 2022-01-05 at 5 19 49 PM" src="https://user-images.githubusercontent.com/52669884/148411984-e9a14d25-85ad-440b-85d0-c6a6b10f5a04.png">


