### PR TITLE
Rp update duty location

### DIFF
--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -231,16 +231,15 @@ class PrimeTasks(PrimeDataStorageMixin, CertTaskMixin, TaskSet):
         if resp.status_code != 200:
             self.interrupt()
 
-        logged_in_user = self.client.get(self.customer_path("/internal/users/logged_in"))
-        json_resp = logged_in_user.json()
-        service_member_id = json_resp["service_member"]["id"]
-        email = json_resp["email"]
-        user_id = json_resp["id"]
+        resp = self.client.get(self.customer_path("/internal/users/logged_in"))
+        logged_in_user = resp.json()
+        service_member_id = logged_in_user["service_member"]["id"]
+        email = logged_in_user["email"]
+        user_id = logged_in_user["id"]
 
         # Setup customer profile
-        duty_stations = self.client.get(self.customer_path("/internal/duty_stations?search=white%20sands"))
-        stations = duty_stations.json()
-        current_station_id = stations[0]["id"]
+        resp = self.client.get(self.customer_path("/internal/duty_locations?search=white%20sands"))
+        duty_locations = resp.json()
 
         overrides = {
             "id": service_member_id,
@@ -248,7 +247,7 @@ class PrimeTasks(PrimeDataStorageMixin, CertTaskMixin, TaskSet):
             "edipi": "9999999999",
             "personal_email": email,
             "email_is_preferred": True,
-            "current_station_id": current_station_id,
+            "current_station_id": duty_locations[0]["id"],
         }
 
         payload = fake_data_generator.generate_fake_request_data(
@@ -290,7 +289,7 @@ class PrimeTasks(PrimeDataStorageMixin, CertTaskMixin, TaskSet):
             "orders_type": "PERMANENT_CHANGE_OF_STATION",
             "has_dependents": False,
             "spouse_has_pro_gear": False,
-            "new_duty_station_id": stations[1]["id"],
+            "new_duty_station_id": duty_locations[1]["id"],
             "orders_number": None,
             "tac": None,
             "sac": None,

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -238,7 +238,7 @@ class PrimeTasks(PrimeDataStorageMixin, CertTaskMixin, TaskSet):
         user_id = json_resp["id"]
 
         # Setup customer profile
-        duty_stations = self.client.get(self.customer_path("/internal/duty_stations?search=palms"))
+        duty_stations = self.client.get(self.customer_path("/internal/duty_stations?search=whitesands"))
         stations = duty_stations.json()
         current_station_id = stations[0]["id"]
 

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -238,7 +238,7 @@ class PrimeTasks(PrimeDataStorageMixin, CertTaskMixin, TaskSet):
         user_id = json_resp["id"]
 
         # Setup customer profile
-        duty_stations = self.client.get(self.customer_path("/internal/duty_stations?search=whitesands"))
+        duty_stations = self.client.get(self.customer_path("/internal/duty_stations?search=white%20sands"))
         stations = duty_stations.json()
         current_station_id = stations[0]["id"]
 


### PR DESCRIPTION
## Description

Changing the default origin duty location for moves created within the prime setup to belong in the `KKFA` GBLOC

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Reset local DB (in mymove repo):
```
make db_dev_reset
make db_dev_migrate
```

Run local back-end server (in mymove repo):
```
make client_run
```

Run front-end server (in mymove repo):
```
make server_run
```

Run the load test (in milmove_load_testing repo):
```
make load_test_prime
```
You can cancel this test as soon as you see the `/internal/moves/{moveId}/submit` test succeed. 

You should then log into the local office Service counselor to confirm that you can see the move that was created by the prime load test. (If you cleared your DB and only run the prime tests with one user you should only see one move on the office app.)
