### PR TITLE
MB-10534 Add docs for expected failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,7 +999,7 @@ is the main recommendation in this repo.
 
 There may be times that you want to create a load test that you expect to fail. E.g. if you want a
 load test to cover an endpoint that will reject the request because of some error (eTag, bad data,
-etc.). If you want to do that, you can do something like this (it's a bit long because of setup):
+etc.). If you want to do that, you can do something like this:
 
 ```python
 # -*- coding: utf-8 -*-
@@ -1048,54 +1048,14 @@ class PrimeTasks(RestTaskSet):
     """
     Tries updating an MTO shipment to an invalid status.
     """
-    # Need a move to work with first. For the sake of this example, we'll get a random move that is
-    # available to prime.
-    url, request_kwargs = self.request_preparer.prep_prime_request(endpoint="/moves")
+    # For the sake of brevity, this example won't include the full setup. You can look at the real
+    # PrimeTasks.update_mto_shipment_with_invalid_status method to see the full version.
 
-    if is_local(env=self.env):
-      request_kwargs["timeout"] = 15  # set a timeout of 15sec if we're running locally for this endpoint
+    # This is not how a real mto_shipment would look, but just doing this for the sake of this
+    # example.
+    mto_shipment = {'id': 'TEST123', 'eTag': 12354519}
 
-    with self.rest(method="GET", url=url, **request_kwargs) as resp:
-      resp: RestResponseContextManager
-
-      log_response_info(response=resp)
-
-      if resp.status_code == HTTPStatus.OK:
-        moves: JSONArray = resp.js
-      else:
-        resp.failure("Unable to get moves available to prime.")
-
-        log_response_failure(response=resp)
-
-        return
-
-    move = random.choice(moves)
-
-    # Now we need to retrieve the shipments for this move
-    url, request_kwargs = self.request_preparer.prep_prime_request(
-      endpoint=f"/move-task-orders/{move['id']}",
-      endpoint_name="/move-task-orders/{moveID}",
-    )
-
-    with self.rest(method="GET", url=url, **request_kwargs) as resp:
-      resp: RestResponseContextManager
-
-      log_response_info(response=resp)
-
-      if resp.status_code == HTTPStatus.OK:
-        move: JSONObject = resp.js
-      else:
-        resp.failure("Unable to get the move.")
-
-        log_response_failure(response=resp)
-
-        return
-
-    # Since we're going to try setting an invalid status that the shipments we recieved above can't
-    # be in, we'll just grab a random one.
-
-    mto_shipment = deepcopy(random.choice(move['mtoShipments']))
-
+    # This is an invalid status for a shipment to change to through this endpoint.
     overrides = {"status": "DRAFT"}
 
     # Generate fake payload based on the endpoint's required fields

--- a/README.md
+++ b/README.md
@@ -811,10 +811,11 @@ An example `TaskSet` for this project might be:
 Example of a TaskSet file...
 """
 import logging
+from http import HTTPStatus
 
 from locust import tag, task
 
-from utils.request import log_response_info, log_response_failure
+from utils.request import log_response_failure, log_response_info
 from utils.rest import RestResponseContextManager
 from utils.task import RestTaskSet
 
@@ -857,7 +858,7 @@ class PrimeTasks(RestTaskSet):
       # This function helps us log the response status code uniformly across requests.
       log_response_info(response=resp)
 
-      if resp.status_code == 200:
+      if resp.status_code == HTTPStatus.OK:
         logger.info(f"\nℹ️ {resp.js=}\n")
       else:
         # This function helps us log info about the response and request when there are errors.
@@ -1026,11 +1027,13 @@ Example of a TaskSet file using the fake data generator...
 """
 import logging
 import random
+from http import HTTPStatus
 
 from locust import tag, task
 
 from utils.constants import ZERO_UUID
 from utils.parsers import APIKey, get_api_fake_data_generator
+from utils.request import log_response_failure, log_response_info
 from utils.rest import RestResponseContextManager
 from utils.task import RestTaskSet
 
@@ -1067,14 +1070,19 @@ class SupportTasks(RestTaskSet):
       # `RestResponseContextManager`, which then lets it know what type hints to suggest below.
       resp: RestResponseContextManager
 
-      # Lastly, validate the response and/or log any relevant info:
-      logger.info(f"ℹ️ Status code: {resp.status_code}")
+      # This function helps us log the response status code uniformly across requests.
+      log_response_info(response=resp)
 
-      if isinstance(resp.js, list) and resp.js:
+      if resp.status_code == HTTPStatus.OK:
         moves = resp.js
       else:
         # if you wanted to, you could mark this load test as a failure by doing this:
         resp.failure("No moves found!")
+
+        # This function helps us log info about the response and request when there are errors.
+        log_response_failure(response=resp)
+
+        return
 
     # You can filter more if you need a specific move
     move_to_use = random.choice(moves)
@@ -1110,7 +1118,7 @@ class SupportTasks(RestTaskSet):
     with self.rest(method="POST", url=create_shipment_path, data=payload, **request_kwargs) as resp:
       resp: RestResponseContextManager
 
-      logger.info(f"ℹ️ Status code: {resp.status_code}")
+      log_response_info(response=resp)
 
       # Do whatever else you need to here.
 ```

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -905,7 +905,7 @@ class PrimeTasks(PrimeDataStorageMixin, RestTaskSet):
 
     # You can add the expectedFailure tag so that they can all be run if needed.
 
-    @tag(MTO_SHIPMENT, "updateMTOShipmentStatus", "expectedFailure", "testingTag")
+    @tag(MTO_SHIPMENT, "updateMTOShipmentStatus", "expectedFailure")
     @task
     def update_mto_shipment_with_invalid_status(self) -> None:
         """

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -5,6 +5,7 @@ Place to store auth-related code, e.g. for dealing with certs or session tokens.
 import logging
 import os
 from enum import Enum
+from http import HTTPStatus
 
 from requests import Session
 
@@ -107,4 +108,4 @@ def create_user(request_preparer: MilMoveRequestPreparer, session: Session, user
 
     resp = session.post(url=url, data=payload)
 
-    return resp.status_code == 200
+    return resp.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Description

This adds a section in the docs explaining how to handle expected failures.

Seconday things added:

* While adding this section, I noticed a few places in the README that I forgot to update (e.g. to use `HTTPStatus` or our new `log_response_info` and `log_response_failure` functions). 
* In writing the sample failure load test, I realized:
  * we don't quite have that test so I added it to our real load tests.
  * we had previously had a `list_moves` load test that existed to set the default mto IDs, but we got rid of it when we started creating the move in the `PrimeTasks.on_start` method. I agree we don't need it for that, but realized that we probably should still have load tests for the endpoint itself.

## Reviewer Notes

Did I miss something? Or should something be explained more?

## Setup

If you want to run the new prime tests you can run the full load tests for prime:

```sh
make load_test_prime
```

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-10534) for this change.
