### PR TITLE
MB-10593 Fix flaky fake middle name test

### DIFF
--- a/utils/fake_data.py
+++ b/utils/fake_data.py
@@ -60,9 +60,12 @@ class MilMoveProvider(AddressProvider, DateProvider):
 
     def _set_safe_name(self):
         """
-        Randomly selects a safe full name to use.
+        Randomly selects a safe full name to use and ensure it is at least different from the
+        previous name being used.
         """
-        random_name = self.random_element(self.safe_data["names"])
+        while (random_name := self.random_element(self.safe_data["names"])) == self.current_name:
+            continue  # New random name was the same as the name we were already using so try again.
+
         self.first_name_used = self.middle_name_used = self.last_name_used = False
 
         self.current_name.update(random_name)

--- a/utils/tests/test_fake_data.py
+++ b/utils/tests/test_fake_data.py
@@ -104,7 +104,11 @@ class TestMilMoveProvider:
 
         fake_name2 = self.fake.safe_middle_name()
 
-        assert fake_name1 != self.provider.current_name["middle_name"]
+        # A lot of the fake names have blank middle names, so we only want to check that they aren't
+        # equal if at least one of them isn't blank.
+        if fake_name1 or fake_name2:
+            assert fake_name1 != self.provider.current_name["middle_name"]
+
         assert fake_name2 == self.provider.current_name["middle_name"]
 
         assert fake_name2 in valid_middle_names

--- a/utils/tests/test_fake_data.py
+++ b/utils/tests/test_fake_data.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """ Tests utils/fake_data.py """
 import re
+from copy import deepcopy
 from datetime import datetime
 
 import pytest
@@ -63,15 +64,30 @@ class TestMilMoveProvider:
 
     def test__set_safe_name(self):
         """
-        Tests the current name does not equal empty strings and sets variables to false
+        Tests the current name does not equal empty strings and sets variables to false. Also ensure
+        that we do change the same from the previous one.
         """
+        # We'll set only two names in the safe data to increase the likelihood of the same one being
+        # picked twice. This way we can be more sure that this is working properly. This way we can
+        # also make it so that "all" names have a middle name, which lets us make assertions on it.
+        self.provider.safe_data["names"] = [
+            {"first_name": "Jason", "middle_name": "Theodore", "last_name": "Ash"},
+            {"first_name": "Nevaeh", "middle_name": "Evans", "last_name": "Wilson"},
+        ]
+
         self.provider._set_safe_name()
         assert self.provider.current_name["first_name"] != ""
-        # Can't make assertion on the middle name because some of the names don't have one.
+        assert self.provider.current_name["middle_name"] != ""
         assert self.provider.current_name["last_name"] != ""
         assert self.provider.first_name_used is False
         assert self.provider.middle_name_used is False
         assert self.provider.last_name_used is False
+
+        previous_name = deepcopy(self.provider.current_name)
+
+        self.provider._set_safe_name()
+
+        assert self.provider.current_name != previous_name
 
     def test_safe_first_name(self):
         """


### PR DESCRIPTION
## Description

The test I wrote for the safe middle name generation is flaky because there are a lot of fake names we have without middle names. When I wrote the test and ran it, I guess I just got lucky and didn't have any of my runs select two people without middle names. This fixes it so that the check that compares them only runs if at least one of them is not empty.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

```sh
pytest
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-10593) for this change.