### PR TITLE
MB-11016 Update nix setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -30,7 +30,7 @@ export CHAMBER_RETRIES=20
 if [ ! -r .nix-disable  ] && has nix-env; then
   # set NIX_PROFILE so nix-env operations don't need to manually
   # specify the profile path
-  export NIX_PROFILE=/nix/var/nix/profiles/milmove-load-testing
+  export NIX_PROFILE="/nix/var/nix/profiles/per-user/${LOGNAME}/milmove-load-testing"
 
   nix_dir="nix"
   # add the nix files so that if they change, direnv needs to be reloaded

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,11 +1,6 @@
-# to install
-# nix-env -f nix -i
+# use ./nix/update.sh to install
 #
-# use
-#
-# https://ahobson.github.io/nix-package-search/#/search
-#
-# to find rev for specific package version
+# use https://ahobson.github.io/nix-package-search/#/search to find rev for specific package version
 
 let
   pkgs = import <nixpkgs> {};
@@ -19,7 +14,7 @@ in buildEnv {
       name = "editorconfig-core-c-0.12.1";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "c8ff5bc6f74a2960fab5ae417cd2bb055eab1002";
+      rev = "0093e4e6a9998f1ff59e79ec31f2341770b7bebb";
     }) {}).editorconfig-core-c
 
     (import (builtins.fetchGit {
@@ -27,8 +22,8 @@ in buildEnv {
       name = "python3-3.9.6";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "c8ff5bc6f74a2960fab5ae417cd2bb055eab1002";
-    }) {}).python3
+      rev = "2f216e02f453cf64cb3b06c1e564ea53bdc01fa0";
+    }) {}).python39Full
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
@@ -43,7 +38,7 @@ in buildEnv {
       name = "shellcheck-0.7.2";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "8e1eab9eae4278c9bb1dcae426848a581943db5a";
+      rev = "7cf6cbe49a4f9efa0607437447d256bbd206b0c4";
     }) {}).shellcheck
 
     (import (builtins.fetchGit {
@@ -51,7 +46,7 @@ in buildEnv {
       name = "aws-vault-6.3.1";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "253aecf69ed7595aaefabde779aa6449195bebb7";
+      rev = "3453b89f4bba270e2d82f6248b09b9595bb47f4b";
     }) {}).aws-vault
 
     (import (builtins.fetchGit {
@@ -59,7 +54,7 @@ in buildEnv {
       name = "awscli2-2.2.14";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "14b0f20fa1f56438b74100513c9b1f7c072cf789";
+      rev = "b3519ced7d0de81573ee0f0874657c76f2d944b5";
     }) {}).awscli2
 
     (import (builtins.fetchGit {
@@ -67,7 +62,7 @@ in buildEnv {
       name = "chamber-2.10.2";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "725ef07e543a6f60b534036c684d44e57bb8d5de";
+      rev = "e63d487cd80754ca9ce18d66fa09e0bcb7dce3f7";
     }) {}).chamber
 
     (import (builtins.fetchGit {
@@ -75,7 +70,7 @@ in buildEnv {
       name = "jq-1.6";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "725ef07e543a6f60b534036c684d44e57bb8d5de";
+      rev = "0093e4e6a9998f1ff59e79ec31f2341770b7bebb";
     }) {}).jq
 
 ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,10 +19,10 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "python3-3.9.6";
+      name = "python3-3.9.9";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "2f216e02f453cf64cb3b06c1e564ea53bdc01fa0";
+      rev = "3fdeef8a7ee81787a099cfb57bd91f24c5ec587d";
     }) {}).python39Full
 
     (import (builtins.fetchGit {
@@ -35,34 +35,34 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "shellcheck-0.7.2";
+      name = "shellcheck-0.8.0";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "8e1eab9eae4278c9bb1dcae426848a581943db5a";
+      rev = "de5ab3881e4868dcfa9f75723bd035ce99cb0751";
     }) {}).shellcheck
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "aws-vault-6.3.1";
+      name = "aws-vault-6.4.0";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "253aecf69ed7595aaefabde779aa6449195bebb7";
+      rev = "8bd55a6a5ab05942af769c2aa2494044bff7f625";
     }) {}).aws-vault
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "awscli2-2.2.14";
+      name = "awscli2-2.2.40";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "14b0f20fa1f56438b74100513c9b1f7c072cf789";
+      rev = "6f0b0bb7028cf612298673bf6b5d453bcc7af965";
     }) {}).awscli2
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "chamber-2.10.2";
+      name = "chamber-2.10.7";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "725ef07e543a6f60b534036c684d44e57bb8d5de";
+      rev = "3fdeef8a7ee81787a099cfb57bd91f24c5ec587d";
     }) {}).chamber
 
     (import (builtins.fetchGit {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,7 +14,7 @@ in buildEnv {
       name = "editorconfig-core-c-0.12.1";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "0093e4e6a9998f1ff59e79ec31f2341770b7bebb";
+      rev = "c8ff5bc6f74a2960fab5ae417cd2bb055eab1002";
     }) {}).editorconfig-core-c
 
     (import (builtins.fetchGit {
@@ -38,7 +38,7 @@ in buildEnv {
       name = "shellcheck-0.7.2";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "7cf6cbe49a4f9efa0607437447d256bbd206b0c4";
+      rev = "8e1eab9eae4278c9bb1dcae426848a581943db5a";
     }) {}).shellcheck
 
     (import (builtins.fetchGit {
@@ -46,7 +46,7 @@ in buildEnv {
       name = "aws-vault-6.3.1";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "3453b89f4bba270e2d82f6248b09b9595bb47f4b";
+      rev = "253aecf69ed7595aaefabde779aa6449195bebb7";
     }) {}).aws-vault
 
     (import (builtins.fetchGit {
@@ -54,7 +54,7 @@ in buildEnv {
       name = "awscli2-2.2.14";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "b3519ced7d0de81573ee0f0874657c76f2d944b5";
+      rev = "14b0f20fa1f56438b74100513c9b1f7c072cf789";
     }) {}).awscli2
 
     (import (builtins.fetchGit {
@@ -62,7 +62,7 @@ in buildEnv {
       name = "chamber-2.10.2";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "e63d487cd80754ca9ce18d66fa09e0bcb7dce3f7";
+      rev = "725ef07e543a6f60b534036c684d44e57bb8d5de";
     }) {}).chamber
 
     (import (builtins.fetchGit {
@@ -70,7 +70,7 @@ in buildEnv {
       name = "jq-1.6";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "0093e4e6a9998f1ff59e79ec31f2341770b7bebb";
+      rev = "725ef07e543a6f60b534036c684d44e57bb8d5de";
     }) {}).jq
 
 ];

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -9,7 +9,7 @@ if [ ! -v NIX_PROFILE ]; then
 fi
 
 # make sure this is set, as we unset it for most projects
-export NIX_SSL_CERT_FILE=$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt
+#export NIX_SSL_CERT_FILE=$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # install packages


### PR DESCRIPTION
## Description

Updated `NIX_PROFILE` path for multi-user installs. 

Since I don't have an M1 mac, I wasn't sure which packages needed to be updated for that so I just got newer hashes for all the packages that had one, keeping the same version as before.

Can someone with an M1 mac that uses nix check that this works?

## Setup

1. Follow [`nix` setup instructions](https://github.com/transcom/milmove_load_testing#setup-nix)
