### PR TITLE
[ MB-9711 ] Add some language and locale settings for pipenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -74,6 +74,15 @@ fi
 export LOCAL_CSV_DIR="static/reports"
 export DOCKER_CSV_DIR="/app/$LOCAL_CSV_DIR"
 
+# ----------------------
+# PIPENV LOCALE SETTINGS
+# ----------------------
+# Set the language and locale because macOS has a bug that prevents pipenv from
+# properly detecting the Shell's encoding correctly.
+# source: https://pipenv.pypa.io/en/latest/diagnose/#valueerror-unknown-locale-utf-8
+export LC_ALL='en_US.UTF-8'
+export LANG='en_US.UTF-8'
+
 # ---------------
 # LOCAL OVERRIDES
 # ---------------


### PR DESCRIPTION
## Description

This patch helps folks new to pipenv have a better initial experience
when it comes to running commands. This prevents error messages around
not having `LANG` set in the environment with a link to the
troubleshooting message from the official documentation as well.

## Reviewer Notes

As I checked out the project for the first time, I realized I didn't have certain variables set in my environment. If this happens to others too, they would need these in their environment according to the `pipenv` documentation if they're on macOS.

## Setup

Verify that the everything starts up properly according to the documentation with these variables. Notice if these variables are `unset` before running the code, that these variables are shown in the `pipenv` error messages.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [ ] ~Have the Jira acceptance criteria been met for this change?~

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9711) for this change. _shoehorning this into MB-9711 as that's documentation related. This replaces the need for written documentation as these code changes are enough documentation_
* [This article](https://pipenv.pypa.io/en/latest/diagnose/#valueerror-unknown-locale-utf-8) explains more about the approach used.
