### PR TITLE
MB-11921: Adds weighted randomness to flow shipment types, and NTS shipments

### DIFF
--- a/tasks/queue.py
+++ b/tasks/queue.py
@@ -2,7 +2,7 @@
 from locust import task, TaskSet
 
 from utils.flows import MemoryFlowQueue, QueuableFlow, WorkerQueueType
-from utils.flows.simple_hhg import SimpleHHGFlow
+from utils.flows.simple_hhg import SingleHHGFlow, DoubleHHGFlow, NTSFlow
 from utils.openapi_client import FlowSessionManager
 from utils.request import MilMoveRequestMixin
 
@@ -40,13 +40,19 @@ class MilMoveHHGQueueTasks(QueueTaskSet):
     def on_start(self):
         """ """
 
-    @task
-    def start_milmove_flow(self):
-        """
-        Start a flow and put it on the queue
-        """
+    @task(2)
+    def start_single_hhg_flow(self):
+        f = SingleHHGFlow()
+        self.start_flow(f)
 
-        f = SimpleHHGFlow()
+    @task(1)
+    def start_double_hhg_flow(self):
+        f = DoubleHHGFlow()
+        self.start_flow(f)
+
+    @task(1)
+    def start_nts_flow(self):
+        f = NTSFlow()
         self.start_flow(f)
 
 

--- a/tasks/queue.py
+++ b/tasks/queue.py
@@ -34,7 +34,11 @@ class QueueTaskSet(MilMoveRequestMixin, TaskSet):
 
 class MilMoveHHGQueueTasks(QueueTaskSet):
     """
-    Set of tasks that can be called for the MilMove interface.
+    Creates tasks that traverse the entire flow, from customer through TIO. These tasks largely only differ
+    based on what kind of shipment(s) the customer is adding to their move. Weighted randomness determines how
+    frequently the various customer shipment types are selected.
+
+    See http://docs.locust.io/en/stable/writing-a-locustfile.html#task-decorator for more info
     """
 
     def on_start(self):
@@ -42,16 +46,25 @@ class MilMoveHHGQueueTasks(QueueTaskSet):
 
     @task(2)
     def start_single_hhg_flow(self):
+        """
+        Kicks off a flow where the customer creates a single HHG shipment
+        """
         f = SingleHHGFlow()
         self.start_flow(f)
 
     @task(1)
     def start_double_hhg_flow(self):
+        """
+        Kicks off a flow where the customer creates two seperate HHG shipments
+        """
         f = DoubleHHGFlow()
         self.start_flow(f)
 
     @task(1)
     def start_nts_flow(self):
+        """
+        Kicks off a flow where the customer creates a single NTS shipment
+        """
         f = NTSFlow()
         self.start_flow(f)
 

--- a/utils/flows/simple_hhg.py
+++ b/utils/flows/simple_hhg.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from utils.flows import FlowContext, FlowStep, FlowSequence, SequenceQueableFlow, WorkerQueueType
 
-from utils.flows.steps.milmove import do_hhg_create_move
+from utils.flows.steps.milmove import do_flow_create_single_hhg, do_flow_create_double_hhg, do_flow_create_nts
 from utils.flows.steps.service_counselor import do_hhg_sc_review
 from utils.flows.steps.too import do_hhg_too_approve
 from utils.flows.steps.prime import do_hhg_prime_service_items
@@ -9,13 +9,39 @@ from utils.flows.steps.prime import do_hhg_prime_service_items
 import os
 
 
-class SimpleHHGFlow(SequenceQueableFlow):
+class SingleHHGFlow(SequenceQueableFlow):
     def __init__(self, flow_context: FlowContext = None) -> None:
         super().__init__(flow_context)
 
     def flow_steps(self) -> FlowSequence:
         return [
-            FlowStep(callback=do_hhg_create_move, queue=WorkerQueueType.SERVICE_MEMBER),
+            FlowStep(callback=do_flow_create_single_hhg, queue=WorkerQueueType.SERVICE_MEMBER),
+            FlowStep(callback=do_hhg_sc_review, queue=WorkerQueueType.SERVICE_COUNSELOR),
+            FlowStep(callback=do_hhg_too_approve, queue=WorkerQueueType.TOO),
+            FlowStep(callback=do_hhg_prime_service_items, queue=WorkerQueueType.PRIME),
+        ]
+
+
+class DoubleHHGFlow(SequenceQueableFlow):
+    def __init__(self, flow_context: FlowContext = None) -> None:
+        super().__init__(flow_context)
+
+    def flow_steps(self) -> FlowSequence:
+        return [
+            FlowStep(callback=do_flow_create_double_hhg, queue=WorkerQueueType.SERVICE_MEMBER),
+            FlowStep(callback=do_hhg_sc_review, queue=WorkerQueueType.SERVICE_COUNSELOR),
+            FlowStep(callback=do_hhg_too_approve, queue=WorkerQueueType.TOO),
+            FlowStep(callback=do_hhg_prime_service_items, queue=WorkerQueueType.PRIME),
+        ]
+
+
+class NTSFlow(SequenceQueableFlow):
+    def __init__(self, flow_context: FlowContext = None) -> None:
+        super().__init__(flow_context)
+
+    def flow_steps(self) -> FlowSequence:
+        return [
+            FlowStep(callback=do_flow_create_nts, queue=WorkerQueueType.SERVICE_MEMBER),
             FlowStep(callback=do_hhg_sc_review, queue=WorkerQueueType.SERVICE_COUNSELOR),
             FlowStep(callback=do_hhg_too_approve, queue=WorkerQueueType.TOO),
             FlowStep(callback=do_hhg_prime_service_items, queue=WorkerQueueType.PRIME),
@@ -25,6 +51,6 @@ class SimpleHHGFlow(SequenceQueableFlow):
 if __name__ == "__main__":
     from utils.base import MilMoveEnv
 
-    f = SimpleHHGFlow()
+    f = SingleHHGFlow()
     milmove_env = MilMoveEnv(os.getenv("MILMOVE_ENV", MilMoveEnv.LOCAL))
     f.run_entire_flow(milmove_env)


### PR DESCRIPTION
## Description

This pull request (a rewrite of #155 ) adds additional methods and weighted randomness into the `MilMoveHHGQueueTasks` task set, which call different implementations of the existing simple HHG flow. Those implementations differ by passing into a common function (which does the customer part of a move) a list of shipment types - one HHG, two HHGs, or an NTS - and sending different payloads to the server based on those different shipments.

## Setup

Start locust with a command like

```
locust -f locustfiles/queue.py --host local -u 10
```

Open http://localhost:8089/ and ensure that the user weights for MilMoveHHGUser are >= 1, then start the load tests and validate that no failures are returned or exceptions are thrown.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
