### PR TITLE
Rename duty station to location

### DIFF
--- a/tasks/milmove.py
+++ b/tasks/milmove.py
@@ -201,7 +201,7 @@ class MilMoveTasks(RestTaskSet):
         # Don't care too much about which one for this load test, so just grabbing the first one.
         origin_duty_location = duty_locations[0]
 
-        payload = {"id": service_member_id, "current_station_id": origin_duty_location["id"]}
+        payload = {"id": service_member_id, "current_location_id": origin_duty_location["id"]}
 
         with self.rest(method="PATCH", url=sm_url, data=json.dumps(payload), **sm_request_kwargs) as resp:
             resp: RestResponseContextManager

--- a/tasks/office.py
+++ b/tasks/office.py
@@ -40,8 +40,8 @@ class OfficeDataStorageMixin:
 
     DATA_LIST_MAX: int = 100
     default_mto_ids: Dict[str, Set] = {
-        "destinationDutyStationID": set(),
-        "originDutyStationID": set(),
+        "destinationDutyLocationID": set(),
+        "originDutyLocationID": set(),
     }
     local_store: Dict[str, Dict[str, Dict]] = {
         CUSTOMER: {},
@@ -303,15 +303,15 @@ class ServicesCounselorTasks(OfficeDataStorageMixin, RestTaskSet):
         )
 
         payload = {key: payload[key] for key in ["issueDate", "reportByDate", "ordersType"]}
-        if self.default_mto_ids.get("originDutyStationID"):
-            payload["originDutyStationId"] = random.choice(list(self.default_mto_ids["originDutyStationID"]))
+        if self.default_mto_ids.get("originDutyLocationID"):
+            payload["originDutyLocationId"] = random.choice(list(self.default_mto_ids["originDutyLocationID"]))
         else:
-            payload["originDutyStationId"] = order["originDutyStation"]["id"]
+            payload["originDutyLocationId"] = order["originDutyLocation"]["id"]
 
-        if self.default_mto_ids.get("destinationDutyStationID"):
-            payload["newDutyStationId"] = random.choice(list(self.default_mto_ids["destinationDutyStationID"]))
+        if self.default_mto_ids.get("destinationDutyLocationID"):
+            payload["newDutyLocationId"] = random.choice(list(self.default_mto_ids["destinationDutyLocationID"]))
         else:
-            payload["newDutyStationId"] = order["destinationDutyStation"]["id"]
+            payload["newDutyLocationId"] = order["destinationDutyLocation"]["id"]
 
         # The request may result in validation errors if the underlying move is no longer in needs counseling status
         url, request_kwargs = self.request_preparer.prep_ghc_request(
@@ -504,10 +504,10 @@ class TOOTasks(OfficeDataStorageMixin, RestTaskSet):
 
                 self.add_stored(MOVE_TASK_ORDER, moves["queueMoves"])
 
-                # destination duty stations don't have to be in the office user's GBLOC
-                destination_duty_station_ids = [move["destinationDutyLocation"]["id"] for move in moves["queueMoves"]]
+                # destination duty locations don't have to be in the office user's GBLOC
+                destination_duty_location_ids = [move["destinationDutyLocation"]["id"] for move in moves["queueMoves"]]
 
-                self.default_mto_ids["destinationDutyStationID"].update(destination_duty_station_ids)
+                self.default_mto_ids["destinationDutyLocationID"].update(destination_duty_location_ids)
             else:
                 resp.failure("Unable to get moves queue.")
 
@@ -545,9 +545,9 @@ class TOOTasks(OfficeDataStorageMixin, RestTaskSet):
 
                 self.add_stored(ORDER, order)
 
-                # the origin duty station is not in the queue response and we can't use the destination
+                # the origin duty location is not in the queue response and we can't use the destination
                 # because they could be outside of the office user's GBLOC
-                self.default_mto_ids["originDutyStationID"].add(order["originDutyStation"]["id"])
+                self.default_mto_ids["originDutyLocationID"].add(order["originDutyLocation"]["id"])
             else:
                 resp.failure("Unable to get orders.")
 
@@ -670,15 +670,15 @@ class TOOTasks(OfficeDataStorageMixin, RestTaskSet):
             require_all=True,
         )
 
-        if self.default_mto_ids.get("originDutyStationID"):
-            payload["originDutyStationId"] = random.choice(list(self.default_mto_ids["originDutyStationID"]))
+        if self.default_mto_ids.get("originDutyLocationID"):
+            payload["originDutyLocationId"] = random.choice(list(self.default_mto_ids["originDutyLocationID"]))
         else:
-            payload["originDutyStationId"] = order["originDutyStation"]["id"]
+            payload["originDutyLocationId"] = order["originDutyLocation"]["id"]
 
-        if self.default_mto_ids.get("destinationDutyStationID"):
-            payload["newDutyStationId"] = random.choice(list(self.default_mto_ids["destinationDutyStationID"]))
+        if self.default_mto_ids.get("destinationDutyLocationID"):
+            payload["newDutyLocationId"] = random.choice(list(self.default_mto_ids["destinationDutyLocationID"]))
         else:
-            payload["newDutyStationId"] = order["destinationDutyStation"]["id"]
+            payload["newDutyLocationId"] = order["destinationDutyLocation"]["id"]
 
         url, request_kwargs = self.request_preparer.prep_ghc_request(
             endpoint=f"/orders/{order['id']}",

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -283,7 +283,7 @@ class PrimeTasks(PrimeDataStorageMixin, RestTaskSet):
             "orders_type": "PERMANENT_CHANGE_OF_STATION",
             "has_dependents": False,
             "spouse_has_pro_gear": False,
-            "new_duty_station_id": duty_locations[1]["id"],
+            "new_duty_location_id": duty_locations[1]["id"],
             "orders_number": None,
             "tac": None,
             "sac": None,

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -44,8 +44,8 @@ class PrimeDataStorageMixin:
     # contains the ID values needed when creating moves using createMoveTaskOrder:
     default_mto_ids: Dict[str, str] = {
         "contractorID": "",
-        "destinationDutyStationID": "",
-        "originDutyStationID": "",
+        "destinationDutyLocationID": "",
+        "originDutyLocationID": "",
         "uploadedOrdersID": "",
     }
     local_store: Dict[str, list] = {
@@ -136,8 +136,8 @@ class PrimeDataStorageMixin:
         Given a list of Move Task Orders, gets the four ID values needed to create more MTOs:
           - contractorID
           - uploadedOrdersID
-          - destinationDutyStationID
-          - originDutyStationID
+          - destinationDutyLocationID
+          - originDutyLocationID
 
         To get these values, this function hits the getMoveTaskOrder endpoint in the Support API to get all of the
         details on an MTO. The Prime API doesn't have access to all of this info, which is why we need to use the
@@ -172,11 +172,11 @@ class PrimeDataStorageMixin:
             self.default_mto_ids["uploadedOrdersID"] = order_details.get(
                 "uploadedOrdersID", self.default_mto_ids["uploadedOrdersID"]
             )
-            self.default_mto_ids["destinationDutyStationID"] = order_details.get(
-                "destinationDutyStationID", self.default_mto_ids["destinationDutyStationID"]
+            self.default_mto_ids["destinationDutyLocationID"] = order_details.get(
+                "destinationDutyLocationID", self.default_mto_ids["destinationDutyLocationID"]
             )
-            self.default_mto_ids["originDutyStationID"] = order_details.get(
-                "originDutyStationID", self.default_mto_ids["originDutyStationID"]
+            self.default_mto_ids["originDutyLocationID"] = order_details.get(
+                "originDutyLocationID", self.default_mto_ids["originDutyLocationID"]
             )
 
     def has_all_default_mto_ids(self) -> bool:
@@ -1152,8 +1152,8 @@ class SupportTasks(PrimeDataStorageMixin, RestTaskSet):
                 "status": "APPROVED",
                 "tac": "F8J1",
                 # We need these objects to exist
-                "destinationDutyStationID": self.default_mto_ids["destinationDutyStationID"],
-                "originDutyStationID": self.default_mto_ids["originDutyStationID"],
+                "destinationDutyLocationID": self.default_mto_ids["destinationDutyLocationID"],
+                "originDutyLocationID": self.default_mto_ids["originDutyLocationID"],
                 "uploadedOrdersID": self.default_mto_ids["uploadedOrdersID"],
                 # To avoid the overrides being inserted into these nested objects...
                 "entitlement": {},

--- a/tasks/prime.py
+++ b/tasks/prime.py
@@ -235,7 +235,7 @@ class PrimeTasks(PrimeDataStorageMixin, RestTaskSet):
             "edipi": "9999999999",
             "personal_email": email,
             "email_is_preferred": True,
-            "current_station_id": duty_locations[0]["id"],
+            "current_location_id": duty_locations[0]["id"],
         }
 
         payload = fake_data_generator.generate_fake_request_data(

--- a/tasks/tests/test_prime.py
+++ b/tasks/tests/test_prime.py
@@ -200,8 +200,8 @@ class TestPrimeDataStorageMixin:
                 "json": {
                     "order": {
                         "uploadedOrdersID": "upload1",
-                        "destinationDutyStationID": "",  # purposefully blank, will not count for end of loop
-                        "originDutyStationID": "origin1",
+                        "destinationDutyLocationID": "",  # purposefully blank, will not count for end of loop
+                        "originDutyLocationID": "origin1",
                     },
                 },
             },
@@ -210,8 +210,8 @@ class TestPrimeDataStorageMixin:
                 "status": 200,
                 "json": {
                     "order": {
-                        "destinationDutyStationID": "destination2",
-                        "originDutyStationID": "origin2",
+                        "destinationDutyLocationID": "destination2",
+                        "originDutyLocationID": "origin2",
                     }
                 },
             },
@@ -241,8 +241,8 @@ class TestPrimeDataStorageMixin:
 
         expected_ids = {
             "contractorID": "contractor0",
-            "destinationDutyStationID": "destination2",
-            "originDutyStationID": "origin2",
+            "destinationDutyLocationID": "destination2",
+            "originDutyLocationID": "origin2",
             "uploadedOrdersID": "upload1",
         }
 
@@ -254,8 +254,8 @@ class TestPrimeDataStorageMixin:
                 "json": {
                     "order": {
                         "uploadedOrdersID": "upload101",
-                        "destinationDutyStationID": "destination101",
-                        "originDutyStationID": "origin101",
+                        "destinationDutyLocationID": "destination101",
+                        "originDutyLocationID": "origin101",
                     },
                 },
             }

--- a/utils/parsers.py
+++ b/utils/parsers.py
@@ -487,8 +487,8 @@ class SupportAPIParser(PrimeAPIParser):
             # Cannot create certain nested objects with this endpoint, instead the caller should pass in an ID
             # (in overrides)
             move_orders.pop("uploadedOrders", None)
-            move_orders.pop("originDutyStation", None)
-            move_orders.pop("destinationDutyStation", None)
+            move_orders.pop("originDutyLocation", None)
+            move_orders.pop("destinationDutyLocation", None)
 
             move_orders.pop("id", None)  # id will be returned on creation
             move_orders.pop("customerID", None)  # customerID will be returned on creation


### PR DESCRIPTION
## Description
I renamed all instances of the term `duty station` in load testing code to `duty location`. This terminology change has already been done in the API and application code, so some load tests were failing when they tried to reference non-existent duty station keys in payloads.

Most of these places weren't generating noticeable errors, but I think that's because they were on code paths that were hitting earlier exceptions first. I haven't rigorously tested this hypothesis, but I'm confident that these keys are not used in any of our responses anymore and needed to be updated.

## Setup
Run some load tests and make sure you don't see any exceptions that mention duty stations or duty locations

```sh
make load_test_office
make load_test_prime
make load_test_milmove
```
for example, this exception that was coming from office tests should be fixed now:
<img width="547" alt="image" src="https://user-images.githubusercontent.com/2627844/162297738-13114e92-a5f6-468a-8c4e-0d4b0a1f92c5.png">

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
