### PR TITLE
Fix pytest commands in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,13 +256,13 @@ This project uses [`pytest`](https://docs.pytest.org/en/stable/) as its testing 
 the tests use the command:
 
 ```shell
-pytest --ignore=openapi_client
+pytest
 ```
 
 To see verbose output and any print statements in the tests, use:
 
 ```shell
-pytest -v -s --ignore=openapi_client
+pytest -v -s
 ```
 
 To run a specific test, use:

--- a/README.md
+++ b/README.md
@@ -256,19 +256,19 @@ This project uses [`pytest`](https://docs.pytest.org/en/stable/) as its testing 
 the tests use the command:
 
 ```shell
-pytest
+pytest --ignore=openapi_client
 ```
 
 To see verbose output and any print statements in the tests, use:
 
 ```shell
-pytest -v -s
+pytest -v -s --ignore=openapi_client
 ```
 
 To run a specific test, use:
 
 ```shell
-pytest /utils/tests/test_parsers.py
+pytest utils/tests/test_parsers.py
 ```
 
 For more instructions and examples, please

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ force_exclude = '^/openapi_client'
 
 [tool.pyright]
 include = ['utils/flows']
+
+[tool.pytest.ini_options]
+norecursedirs = ["openapi_client"]


### PR DESCRIPTION
Pytest commands as mentioned in docs don't actually work as-is. 
Fixed.