### PR TITLE
[MB-14473] Update/sync pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3.9
         exclude: ^openapi_client
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.2
+    rev: 5.0.4
     hooks:
       - id: flake8
         exclude: ^openapi_client
@@ -21,7 +21,7 @@ repos:
       - id: hadolint
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
       - id: check-json
@@ -36,7 +36,7 @@ repos:
         exclude: openapi_client
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.27.1
+    rev: v0.32.2
     hooks:
       - id: markdownlint
         entry: markdownlint --ignore .github/*.md --ignore openapi_client/**/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         exclude: ^openapi_client
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         exclude: ^openapi_client


### PR DESCRIPTION
## Description

This PR updates and/or syncs pre-commit hook versions since it looks like it's been a while since we've updated them (and dependabot doesn't catch pre-commit hooks).

~~Note that I held flake8 back to 5.0.4 instead of the very recently released 6.0.0 version to match what's in our Pipfile (ideally, we'd update both in sync, but the dependabot update for the Pipfile hasn't come through yet).~~  **Update:** it looks like the [dependabot PR for flake 6.0.0](https://github.com/transcom/milmove_load_testing/pull/291) is available now, so I went ahead and updated the pre-commit hook to 6.0 too in this PR.  Both PRs should be landed close together.

## Reviewer Notes

Just make sure pre-commit hooks pass in CircleCI.

You can also run a `pre-commit autoupdate` and see if any other updates (besides the flake8 one mentioned above) show up in `.pre-commit-config.yaml`.
