### PR TITLE
MB-16132: Don't hammer the DB for devlocal auth

### DIFF
--- a/utils/auth.py
+++ b/utils/auth.py
@@ -83,7 +83,11 @@ def create_user(request_preparer: MilMoveRequestPreparer, session: Session, user
     """
     # Hacky workaround for now...not sure if this should really be added to the
     # MilMoveRequestPreparer class since it's only needed for this.
-    endpoint = "/devlocal-auth/login"
+
+    # go to /sign-in instead of /devlocal-auth/login because the
+    # latter hits the DB pretty hard in a way that differs from how
+    # things would work in the real world
+    endpoint = "/sign-in"
     if user_type == UserType.MILMOVE:
         url = request_preparer.form_internal_path(endpoint=endpoint, include_prefix=False)
     else:

--- a/utils/tests/test_auth.py
+++ b/utils/tests/test_auth.py
@@ -127,7 +127,7 @@ class TestCreateUser:
 
         create_user(request_preparer=request_preparer, session=mock_session, user_type=user_type)
 
-        mock_session.get.assert_called_once_with(url=f"{base_domain}/devlocal-auth/login")
+        mock_session.get.assert_called_once_with(url=f"{base_domain}/sign-in")
         mock_session.post.assert_called_once_with(
             url=f"{base_domain}/devlocal-auth/create",
             data={


### PR DESCRIPTION
## Description

[Modify load testing to not hammer db using devlocal auth.
](https://dp3.atlassian.net/browse/MB-16132)

Hitting `/devlocal-auth/login` does a pretty suboptimal query that is nothing like what would happen in production.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change.
* [This article](tbd) explains more about the approach used.
