### PR TITLE
MB-16145 better track locust failures, stop flow if error occurs

### DIFF
--- a/utils/flows/__init__.py
+++ b/utils/flows/__init__.py
@@ -81,7 +81,11 @@ class QueuableFlow(ABC):
         flow_step = self.next_step()
         if flow_step:
             flow_step_callback = flow_step["callback"]
-            flow_step_callback(self.flow_context, flow_session_manager)
+            try:
+                flow_step_callback(self.flow_context, flow_session_manager)
+            except Exception:
+                # if any step in the flow fails, stop running the flow
+                return False
         return flow_step is not None
 
     def to_serialized_flow(self) -> SerializedFlow:

--- a/utils/flows/steps/milmove.py
+++ b/utils/flows/steps/milmove.py
@@ -54,7 +54,7 @@ def create_nts_shipment(move_id: str, issue_date: datetime, pickup_address: Addr
     )
 
 
-def start_flow(flow_context: FlowContext, flow_session_manager: FlowSessionManager, shipments: list[str]) -> None:
+def do_flow(flow_context: FlowContext, flow_session_manager: FlowSessionManager, shipments: list[str]) -> None:
     """
     Creates a move. Can raise internal_client.ApiException
     """
@@ -208,18 +208,18 @@ def do_flow_create_single_hhg(
     flow_context: FlowContext,
     flow_session_manager: FlowSessionManager,
 ) -> None:
-    start_flow(flow_context, flow_session_manager, ["HHG"])
+    do_flow(flow_context, flow_session_manager, ["HHG"])
 
 
 def do_flow_create_double_hhg(
     flow_context: FlowContext,
     flow_session_manager: FlowSessionManager,
 ) -> None:
-    start_flow(flow_context, flow_session_manager, ["HHG", "HHG"])
+    do_flow(flow_context, flow_session_manager, ["HHG", "HHG"])
 
 
 def do_flow_create_nts(
     flow_context: FlowContext,
     flow_session_manager: FlowSessionManager,
 ) -> None:
-    start_flow(flow_context, flow_session_manager, ["NTS"])
+    do_flow(flow_context, flow_session_manager, ["NTS"])

--- a/utils/openapi_client.py
+++ b/utils/openapi_client.py
@@ -270,9 +270,15 @@ class FlowSessionManager(object):
                 cert_file = rkwargs["cert"][0]
                 key_file = rkwargs["cert"][1]
 
-        # defaults from the generated internal client
-        pools_size = 4
-        maxsize = 4
+        num_users = 10
+        if self.user:
+            num_users = self.user.environment.parsed_options.num_users
+
+        # as a rough approximation, use a pool size that is 1/3 of the
+        # number of users, as we have service members, office users,
+        # and the prime, but make sure we have at least 4
+        pools_size = max(4, int(num_users / 3))
+        maxsize = pools_size
         pool_manager = urllib3.PoolManager(
             num_pools=pools_size,
             maxsize=maxsize,

--- a/utils/openapi_client.py
+++ b/utils/openapi_client.py
@@ -22,10 +22,11 @@ import internal_client
 import ghc_client
 import prime_client
 
+from http import HTTPStatus
 import requests
 import requests.cookies
 
-from utils.auth import create_user, UserType
+from utils.auth import create_user, SessionCaller, SessionTracker, UserType
 from utils.base import MilMoveEnv
 
 
@@ -154,14 +155,65 @@ class LocustOpenAPIPoolManager(PoolManager):
 
 class FlowSessionManager(object):
     request_preparer: MilMoveRequestPreparer
+    user: Optional[User]
+    session_tracker: SessionTracker
 
     def __init__(self, milmove_env: MilMoveEnv, user: Optional[User]) -> None:
         self.request_preparer = MilMoveRequestPreparer(env=milmove_env)
         self.user = user
 
+        def locust_session_tracker(method: str, url: str, session_caller: SessionCaller) -> bool:
+            start_time = time.time()
+            start_perf_counter = time.perf_counter()
+            resp = session_caller()
+            response_time = (time.perf_counter() - start_perf_counter) * 1000
+
+            if not user:
+                return resp.status_code == HTTPStatus.OK
+
+            context = {}
+            if user:
+                context = {**user.context(), **context}
+            request_meta = {
+                "request_type": method,
+                "name": url,
+                "start_time": start_time,
+                "response": resp,
+                "response_time": response_time,
+                "response_length": len(resp.content or b""),
+                "context": context,
+                "exception": None,
+            }
+
+            try:
+                resp.raise_for_status()
+            except requests.exceptions.RequestException as e:
+                while (
+                    isinstance(
+                        e,
+                        (
+                            requests.exceptions.ConnectionError,
+                            urllib3.exceptions.ProtocolError,
+                            urllib3.exceptions.MaxRetryError,
+                            urllib3.exceptions.NewConnectionError,
+                        ),
+                    )
+                    and e.__context__  # Not sure if the above exceptions can ever be the lowest level, but it is good to be sure
+                ):
+                    e = e.__context__
+                request_meta["exception"] = e
+
+            user.environment.events.request.fire(**request_meta)
+
+            if request_meta["exception"]:
+                return False
+            return True
+
+        self.session_tracker = locust_session_tracker
+
     def internal_api_client(self, user_type: UserType) -> LocustInternalApiClient:
         session = requests.Session()
-        if not create_user(self.request_preparer, session, user_type):
+        if not create_user(self.session_tracker, self.request_preparer, session, user_type):
             raise Exception(f"Cannot create user: {user_type}")
 
         host = self.request_preparer.form_internal_path("")
@@ -176,7 +228,7 @@ class FlowSessionManager(object):
 
     def ghc_api_client(self, user_type: UserType) -> LocustGHCApiClient:
         session = requests.Session()
-        if not create_user(self.request_preparer, session, user_type):
+        if not create_user(self.session_tracker, self.request_preparer, session, user_type):
             raise Exception(f"Cannot create user: {user_type}")
 
         host = self.request_preparer.form_ghc_path("")


### PR DESCRIPTION
## Description

Use locust to track the status of devlocal auth interactions. Stop processing the flow if an error occurs

This is an attempt to have locust stats for errors match the errors in the server logs
