### PR TITLE
Go back to installing pipenv via nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -46,10 +46,6 @@ if [ ! -r .nix-disable  ] && has nix-env; then
   # add the NIX_PROFILE bin path so that everything we just installed
   # is available on the path
   PATH_add "${NIX_PROFILE}/bin"
-
-  # Use a venv for installing pipenv
-  export PIPENV_VENV_DIR="${PWD}/.venv"
-  PATH_add "${PIPENV_VENV_DIR}/bin"
 fi
 
 # Loads secrets from chamber instead of requiring them to be listed in .envrc.local

--- a/README.md
+++ b/README.md
@@ -280,9 +280,8 @@ To update python to a new version, you need to modify multiple files:
 1. Update the `load_tester` image in the `mymove/.circleci/config.yml`
    to the right version
 
-NOTE: nix installs pipenv with its own bundled version of python, so
-nix installs create a venv to install pipenv with the configured
-version of python
+NOTE: nix installs pipenv with its own bundled version of python, but
+pipenv can create virtual envs for other versions of python.
 
 ## Updating Pipenv Version
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -27,6 +27,14 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
+      name = "pipenv-2023.2.4";
+      url = "https://github.com/NixOS/nixpkgs/";
+      ref = "refs/heads/nixpkgs-unstable";
+      rev = "21eb6c6ba74dcbe3ea5926ee46287300fb066630";
+    }) {}).pipenv
+
+    (import (builtins.fetchGit {
+      # Descriptive name to make the store path easier to identify
       name = "shellcheck-0.8.0";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -16,14 +16,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # install packages
 nix-env -f "${DIR}" -i
 
-# install pipenv manually to ensure pipenv uses the installed version
-# of python
-if [ -n "${PIPENV_VENV_DIR:-}" ]; then
-  rm -rf "${PIPENV_VENV_DIR}" &&
-    python -m venv "${PIPENV_VENV_DIR}" &&
-    "${PIPENV_VENV_DIR}"/bin/pip3 install pipenv==2023.2.4
-fi
-
 # Store a hash of this file to the hash of the nix profile
 # This way if the config changes, we can warn about it via direnv
 # See the nix config in .envrc


### PR DESCRIPTION
## Description

After more experimentation and testing, I confirmed that pipenv can create python enviornments for the installed version of python which is different from the version of python used to install pipenv itself.
