### PR TITLE
updated create order parameters for locust tests

### DIFF
--- a/utils/flows/steps/milmove.py
+++ b/utils/flows/steps/milmove.py
@@ -24,6 +24,7 @@ from internal_client.model.patch_service_member_payload import PatchServiceMembe
 from internal_client.model.address import Address
 from internal_client.model.affiliation import Affiliation
 from internal_client.model.create_service_member_backup_contact_payload import CreateServiceMemberBackupContactPayload
+from internal_client.model.order_pay_grade import OrderPayGrade
 from internal_client.model.backup_contact_permission import BackupContactPermission
 from internal_client.model.create_update_orders import CreateUpdateOrders
 from internal_client.model.orders_type import OrdersType
@@ -166,9 +167,11 @@ def do_flow(
             orders_type=OrdersType("PERMANENT_CHANGE_OF_STATION"),
             has_dependents=False,
             spouse_has_pro_gear=False,
+            origin_duty_location_id=duty_location_id,
             new_duty_location_id=new_duty_location_id,
             orders_type_detail=odt,
             department_indicator=DeptIndicator("ARMY"),
+            grade=OrderPayGrade("E_1"),
         ),
         # looks like the python openapi code generator doesn't
         # handle a $ref that is also x-nullable?


### PR DESCRIPTION
[Ticket B-18519](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A894599)

## Description

Had to dive into hosting locust locally and testing against a locally running milmove db. From this, I was able to debug the milmove handler and find missing / incorrect parameters. Then, just updating the locust test file accordingly.

Please see "This pull request" section to see why the failure was not identified. Going forward, if we automate this, then we'll need to update the pipeline into main to check for any failing locust tests based on changes.

## What was missing:

### Previous pull request
Since we removed rank from the service member and tied everything to now be based on the order pay grade, load tests were still using "ServiceMemberRank" which no longer existed in swagger. A previous pull request removed this.

### This pull request

We had to import OrderPayGrade from swagger and pass that into the order creation. The previous pull request removed the faulty service member rank, but no tests during the merge into main indicated locust tests would fail due to a missing order pay grade.

## Screenshots

See passing tests with 0% failures

<img width="1640" alt="image" src="https://github.com/transcom/milmove_load_testing/assets/136814362/d3c3788e-4dcd-48a2-b196-08af439339ca">

## Targeted

https://github.com/transcom/mymove/pull/11893 was targeted for these locust tests