### PR TITLE
Stop generating random postal codes so that county lookup works

### DIFF
--- a/utils/flows/steps/milmove.py
+++ b/utils/flows/steps/milmove.py
@@ -129,7 +129,7 @@ def do_flow(
             street_address2="P.O. Box " + fake.building_number(),
             city=fake.city(),
             state=state,
-            postal_code=fake.postcode(),
+            postal_code="67449",
         ),
     )
 


### PR DESCRIPTION
## Summary

Work done as part of [B-18798](https://github.com/transcom/mymove/pull/12348/files#diff-c746751dbab37ada7a220eadb1e197830634fc397ecf9efed38d5dfaeebcfa94) and upcoming work as part of [B-18799](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18799) will require valid zip codes in milmove_load_testing so that county lookups can be completed. 

The use of fake.postcode() was generating random zip codes that are invalid, which would cause the county lookup to fail when trying to patch the service member.